### PR TITLE
Handle specially the key of Float32x4Array and Int32x4Array element storing for arm and x64 port

### DIFF
--- a/src/arm/lithium-arm.cc
+++ b/src/arm/lithium-arm.cc
@@ -2174,10 +2174,12 @@ LInstruction* LChunkBuilder::DoStoreKeyed(HStoreKeyed* instr) {
          (instr->is_external() &&
           instr->elements()->representation().IsExternal()));
   LOperand* val = UseRegister(instr->value());
-  LOperand* key = UseRegisterOrConstantAtStart(instr->key());
   LOperand* backing_store = UseRegister(instr->elements());
   bool store_128bits_without_neon =
       IsSIMD128ElementsKind(instr->elements_kind());
+  LOperand* key = store_128bits_without_neon
+      ? UseRegisterOrConstant(instr->key())
+      : UseRegisterOrConstantAtStart(instr->key());
   LStoreKeyed* result =
       new(zone()) LStoreKeyed(backing_store, key, val,
           store_128bits_without_neon ? TempRegister() : NULL);

--- a/src/x64/lithium-codegen-x64.cc
+++ b/src/x64/lithium-codegen-x64.cc
@@ -2994,12 +2994,12 @@ void LCodeGen::DoLoadKeyedSIMD128ExternalArray(LLoadKeyed* instr) {
 
   // Allocate a SIMD128 object on the heap.
   Register reg = ToRegister(instr->result());
+  Register tmp = ToRegister(instr->temp());
   DeferredSIMD128ToTagged* deferred =
       new(zone()) DeferredSIMD128ToTagged(this, instr,
           static_cast<Runtime::FunctionId>(T::kRuntimeAllocatorId()));
   if (FLAG_inline_new) {
-    __ AllocateSIMDHeapObject(Float32x4::kSize, reg, kScratchRegister,
-        deferred->entry(),
+    __ AllocateSIMDHeapObject(T::kSize, reg, tmp, deferred->entry(),
         static_cast<Heap::RootListIndex>(T::kMapRootIndex()));
   } else {
     __ jmp(deferred->entry());
@@ -3018,9 +3018,8 @@ void LCodeGen::DoLoadKeyedSIMD128ExternalArray(LLoadKeyed* instr) {
         elements_kind,
         base_offset + offset,
         instr->additional_index()));
-    __ movp(kScratchRegister, operand);
-    __ movp(FieldOperand(reg, Float32x4::kValueOffset + offset),
-        kScratchRegister);
+    __ movp(tmp, operand);
+    __ movp(FieldOperand(reg, T::kValueOffset + offset), tmp);
   }
 }
 

--- a/src/x64/lithium-x64.h
+++ b/src/x64/lithium-x64.h
@@ -1526,11 +1526,12 @@ class LLoadExternalArrayPointer V8_FINAL
 };
 
 
-class LLoadKeyed V8_FINAL : public LTemplateInstruction<1, 2, 0> {
+class LLoadKeyed V8_FINAL : public LTemplateInstruction<1, 2, 1> {
  public:
-  LLoadKeyed(LOperand* elements, LOperand* key) {
+  LLoadKeyed(LOperand* elements, LOperand* key, LOperand* temp) {
     inputs_[0] = elements;
     inputs_[1] = key;
+    temps_[0] = temp;
   }
 
   DECLARE_CONCRETE_INSTRUCTION(LoadKeyed, "load-keyed")
@@ -1547,6 +1548,7 @@ class LLoadKeyed V8_FINAL : public LTemplateInstruction<1, 2, 0> {
   }
   LOperand* elements() { return inputs_[0]; }
   LOperand* key() { return inputs_[1]; }
+  LOperand* temp() { return temps_[0]; }
   virtual void PrintDataTo(StringStream* stream) V8_OVERRIDE;
   uint32_t additional_index() const { return hydrogen()->index_offset(); }
   ElementsKind elements_kind() const {


### PR DESCRIPTION
Handle specially the key of Float32x4Array and Int32x4Array element storing for arm and x64 port, use temp register instead of kScratchRegister when calling AllocateSIMDHeapObject in x64 port.

This commit should be squashed with the previous commit.
