### PR TITLE
V8 profiling patch rebased on Chromuim v34

### DIFF
--- a/build/features.gypi
+++ b/build/features.gypi
@@ -43,6 +43,9 @@
 
     'v8_use_snapshot%': 'true',
 
+     # Enable XDK profiling support by default.
+    'v8_enable_xdkprof': 1,
+
     # With post mortem support enabled, metadata is embedded into libv8 that
     # describes various parameters of the VM for use by debuggers. See
     # tools/gen-postmortem-metadata.py for details.

--- a/src/log.cc
+++ b/src/log.cc
@@ -43,6 +43,9 @@
 #include "string-stream.h"
 #include "vm-state-inl.h"
 
+// XDK support
+#include "third_party/xdk/xdk-v8.h"
+
 namespace v8 {
 namespace internal {
 
@@ -155,6 +158,15 @@ class CodeEventLogger::NameBuffer {
     Vector<char> buffer(utf8_buffer_ + utf8_pos_,
                         kUtf8BufferSize - utf8_pos_);
     int size = OS::SNPrintF(buffer, "%x", n);
+    if (size > 0 && utf8_pos_ + size <= kUtf8BufferSize) {
+      utf8_pos_ += size;
+    }
+  }
+
+  // XDK needs this function temporary. It will be removed later.
+  void AppendAddress(Address address) {
+    Vector<char> buffer(utf8_buffer_ + utf8_pos_, kUtf8BufferSize - utf8_pos_);
+    int size = OS::SNPrintF(buffer, "0x%x", address);
     if (size > 0 && utf8_pos_ + size <= kUtf8BufferSize) {
       utf8_pos_ += size;
     }
@@ -656,6 +668,226 @@ class JitLogger : public CodeEventLogger {
   void* StartCodePosInfoEvent();
   void EndCodePosInfoEvent(Code* code, void* jit_handler_data);
 
+  // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  // XDK needs all this suff below to generate the strings like
+  // "code-creation:..." in the same format as Logger generates.
+  // This string is sent to XDK by code_event_handler and then used for
+  // postprocessing. All these CodeCreateEvent(...) functions and helpers
+  // will be removed before commit.
+  void AppendCodeCreateHeader(NameBuffer* msg,
+                              Logger::LogEventsAndTags tag,
+                              Code* code) {
+    CHECK(msg);
+    msg->AppendBytes(kLogEventsNames[Logger::CODE_CREATION_EVENT]);
+    msg->AppendByte(',');
+    msg->AppendBytes(kLogEventsNames[tag]);
+    msg->AppendByte(',');
+    msg->AppendInt(code->kind());
+    msg->AppendByte(',');
+    msg->AppendAddress(code->instruction_start());
+    msg->AppendByte(',');
+    msg->AppendInt(code->instruction_size());
+    msg->AppendByte(',');
+  }
+
+
+  void AppendDetailed(NameBuffer* msg, String* str, bool show_impl_info) {
+    CHECK(msg);
+    if (str == NULL) return;
+    DisallowHeapAllocation no_gc;  // Ensure string stay valid.
+    int len = str->length();
+    if (len > 0x1000)
+      len = 0x1000;
+    if (show_impl_info) {
+      msg->AppendByte(str->IsOneByteRepresentation() ? 'a' : '2');
+      if (StringShape(str).IsExternal())
+        msg->AppendByte('e');
+      if (StringShape(str).IsInternalized())
+        msg->AppendByte('#');
+      msg->AppendByte(':');
+      msg->AppendInt(str->length());
+      msg->AppendByte(':');
+    }
+    for (int i = 0; i < len; i++) {
+      uc32 c = str->Get(i);
+      if (c > 0xff) {
+        msg->AppendBytes("\\u");
+        msg->AppendHex(c);
+      } else if (c < 32 || c > 126) {
+        msg->AppendBytes("\\x");
+        msg->AppendHex(c);
+      } else if (c == ',') {
+        msg->AppendBytes("\\,");
+      } else if (c == '\\') {
+        msg->AppendBytes("\\\\");
+      } else if (c == '\"') {
+        msg->AppendBytes("\"\"");
+      } else {
+        msg->AppendByte(c);
+      }
+    }
+  }
+
+
+  void AppendDoubleQuotedString(NameBuffer* msg, const char* string) {
+    CHECK(msg);
+    msg->AppendByte('"');
+    for (const char* p = string; *p != '\0'; p++) {
+      if (*p == '"') {
+        msg->AppendByte('\\');
+     }
+      msg->AppendByte(*p);
+    }
+    msg->AppendByte('"');
+  }
+
+  void AppendSymbolName(NameBuffer* msg, Symbol* symbol) {
+    CHECK(msg);
+    ASSERT(symbol);
+    msg->AppendBytes("symbol(");
+    if (!symbol->name()->IsUndefined()) {
+      msg->AppendByte('"');
+      AppendDetailed(msg, String::cast(symbol->name()), false);
+      msg->AppendBytes("\" ");
+    }
+    msg->AppendBytes("hash ");
+    msg->AppendHex(symbol->Hash());
+    msg->AppendByte(')');
+  }
+
+
+  virtual void CodeCreateEvent(Logger::LogEventsAndTags tag,
+                               Code* code, const char* comment) {
+    name_buffer_->Reset();
+    AppendCodeCreateHeader(name_buffer_, tag, code);
+    AppendDoubleQuotedString(name_buffer_, comment);
+    LogRecordedBuffer(code, NULL, name_buffer_->get(), name_buffer_->size());
+  }
+
+
+  virtual void CodeCreateEvent(Logger::LogEventsAndTags tag,
+                               Code* code, Name* name) {
+    name_buffer_->Reset();
+    AppendCodeCreateHeader(name_buffer_, tag, code);
+    if (name->IsString()) {
+      name_buffer_->AppendByte('"');
+      AppendDetailed(name_buffer_, String::cast(name), false);
+      name_buffer_->AppendByte('"');
+    } else {
+      AppendSymbolName(name_buffer_, Symbol::cast(name));
+    }
+    LogRecordedBuffer(code, NULL, name_buffer_->get(), name_buffer_->size());
+  }
+
+
+  virtual void CodeCreateEvent(Logger::LogEventsAndTags tag,
+                                 Code* code,
+                                 SharedFunctionInfo* shared,
+                                 CompilationInfo* info,
+                                 Name* name) {
+    name_buffer_->Reset();
+    AppendCodeCreateHeader(name_buffer_, tag, code);
+    if (name->IsString()) {
+      SmartArrayPointer<char> str =
+         String::cast(name)->ToCString(DISALLOW_NULLS, ROBUST_STRING_TRAVERSAL);
+      name_buffer_->AppendByte('"');
+      name_buffer_->AppendBytes(str.get());
+      name_buffer_->AppendByte('"');
+    } else {
+      AppendSymbolName(name_buffer_, Symbol::cast(name));
+    }
+    name_buffer_->AppendByte(',');
+    name_buffer_->AppendAddress(shared->address());
+    name_buffer_->AppendByte(',');
+    name_buffer_->AppendBytes(ComputeMarker(code));
+    LogRecordedBuffer(code, shared, name_buffer_->get(), name_buffer_->size());
+  }
+
+
+  virtual void CodeCreateEvent(Logger::LogEventsAndTags tag,
+                                 Code* code,
+                                 SharedFunctionInfo* shared,
+                                 CompilationInfo* info,
+                                 Name* source,
+                                 int line, int column) {
+    name_buffer_->Reset();
+    AppendCodeCreateHeader(name_buffer_, tag, code);
+    SmartArrayPointer<char> name =
+        shared->DebugName()->ToCString(DISALLOW_NULLS, ROBUST_STRING_TRAVERSAL);
+    name_buffer_->AppendByte('"');
+    name_buffer_->AppendBytes(name.get());
+    name_buffer_->AppendByte(' ');
+    if (source->IsString()) {
+        SmartArrayPointer<char> sourcestr =
+           String::cast(source)->ToCString(DISALLOW_NULLS,
+                                           ROBUST_STRING_TRAVERSAL);
+        name_buffer_->AppendBytes(sourcestr.get());
+    } else {
+        AppendSymbolName(name_buffer_, Symbol::cast(source));
+    }
+    name_buffer_->AppendByte(':');
+    name_buffer_->AppendInt(line);
+    name_buffer_->AppendByte(':');
+    name_buffer_->AppendInt(column);
+    name_buffer_->AppendBytes("\",");
+    name_buffer_->AppendAddress(shared->address());
+    name_buffer_->AppendByte(',');
+    name_buffer_->AppendBytes(ComputeMarker(code));
+    LogRecordedBuffer(code, shared, name_buffer_->get(), name_buffer_->size());
+  }
+
+
+  virtual void CodeCreateEvent(Logger::LogEventsAndTags tag,
+                               Code* code,
+                               SharedFunctionInfo* shared,
+                               CompilationInfo* info,
+                               Name* source,
+                               int line) {
+    name_buffer_->Reset();
+    AppendCodeCreateHeader(name_buffer_, tag, code);
+    SmartArrayPointer<char> name =
+        shared->DebugName()->ToCString(DISALLOW_NULLS, ROBUST_STRING_TRAVERSAL);
+    name_buffer_->AppendByte('"');
+    name_buffer_->AppendBytes(name.get());
+    name_buffer_->AppendByte(' ');
+    if (source->IsString()) {
+        SmartArrayPointer<char> sourcestr =
+           String::cast(source)->ToCString(DISALLOW_NULLS,
+                                           ROBUST_STRING_TRAVERSAL);
+        name_buffer_->AppendBytes(sourcestr.get());
+    } else {
+        AppendSymbolName(name_buffer_, Symbol::cast(source));
+    }
+    name_buffer_->AppendByte(':');
+    name_buffer_->AppendInt(line);
+    name_buffer_->AppendBytes("\",");
+    name_buffer_->AppendAddress(shared->address());
+    name_buffer_->AppendByte(',');
+    name_buffer_->AppendBytes(ComputeMarker(code));
+    LogRecordedBuffer(code, shared, name_buffer_->get(), name_buffer_->size());
+  }
+
+
+  virtual void CodeCreateEvent(Logger::LogEventsAndTags tag,
+                               Code* code,
+                               int args_count) {
+    name_buffer_->Reset();
+    AppendCodeCreateHeader(name_buffer_, tag, code);
+    name_buffer_->AppendBytes("\"args_count: ");
+    name_buffer_->AppendInt(args_count);
+    name_buffer_->AppendByte('"');
+  }
+
+
+  virtual void RegExpCodeCreateEvent(Code* code, String* source) {
+    name_buffer_->Reset();
+    AppendCodeCreateHeader(name_buffer_, Logger::REG_EXP_TAG, code);
+    name_buffer_->AppendByte('"');
+    AppendDetailed(name_buffer_, source, false);
+    name_buffer_->AppendByte('"');
+  }
+  // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
  private:
   virtual void LogRecordedBuffer(Code* code,
                                  SharedFunctionInfo* shared,
@@ -758,6 +990,7 @@ void JitLogger::EndCodePosInfoEvent(Code* code, void* jit_handler_data) {
 
   code_event_handler_(&event);
 }
+
 
 
 // The Profiler samples pc and sp values for the main thread.
@@ -1376,8 +1609,8 @@ static void AppendCodeCreateHeader(Log::MessageBuilder* msg,
               kLogEventsNames[Logger::CODE_CREATION_EVENT],
               kLogEventsNames[tag],
               code->kind());
-  msg->AppendAddress(code->address());
-  msg->Append(",%d,", code->ExecutableSize());
+  msg->AppendAddress(code->instruction_start());
+  msg->Append(",%d,", code->instruction_size());
 }
 
 
@@ -1623,11 +1856,18 @@ void Logger::MoveEventInternal(LogEventsAndTags event,
                                Address from,
                                Address to) {
   if (!FLAG_log_code || !log_->IsEnabled()) return;
+
+  Code* from_code = Code::cast(HeapObject::FromAddress(from));
+  const size_t header_size =
+    from_code->instruction_start() - reinterpret_cast<byte*>(from_code);
+  Address to_code =
+    reinterpret_cast<byte*>(HeapObject::FromAddress(to)) + header_size;
+
   Log::MessageBuilder msg(log_);
   msg.Append("%s,", kLogEventsNames[event]);
-  msg.AppendAddress(from);
+  msg.AppendAddress(from_code->instruction_start());
   msg.Append(',');
-  msg.AppendAddress(to);
+  msg.AppendAddress(to_code);
   msg.Append('\n');
   msg.WriteToLogFile();
 }
@@ -1745,6 +1985,15 @@ void Logger::TickEvent(TickSample* sample, bool overflow) {
   }
   msg.Append('\n');
   msg.WriteToLogFile();
+}
+
+
+void Logger::XDKResumeProfiler() {
+  if (!log_->IsEnabled()) return;
+  if (profiler_ != NULL) {
+    profiler_->resume();
+    is_logging_ = true;
+  }
 }
 
 
@@ -1886,6 +2135,12 @@ void Logger::LogCodeObject(Object* object) {
 
 
 void Logger::LogCodeObjects() {
+  // Starting from Chromium v34 this function is also called from
+  // V8::Initialize. This causes reading the heap to collect already
+  // compiled methods. For XDK that must be done because XDK profiler
+  // consumes CODE_ADDED events and mantains a map of compiled methods.
+  return; 
+
   Heap* heap = isolate_->heap();
   heap->CollectAllGarbage(Heap::kMakeHeapIterableMask,
                           "Logger::LogCodeObjects");
@@ -1946,6 +2201,12 @@ void Logger::LogExistingFunction(Handle<SharedFunctionInfo> shared,
 
 
 void Logger::LogCompiledFunctions() {
+  // Starting from Chromium v34 this function is also called from
+  // V8::Initialize. This causes reading the heap to collect already
+  // compiled methods. For XDK that must be done because XDK profiler
+  // consumes CODE_ADDED events and mantains a map of compiled methods.
+  return; 
+
   Heap* heap = isolate_->heap();
   heap->CollectAllGarbage(Heap::kMakeHeapIterableMask,
                           "Logger::LogCompiledFunctions");
@@ -2081,10 +2342,17 @@ bool Logger::SetUp(Isolate* isolate) {
     is_logging_ = true;
   }
 
+  xdk::XDKInitializeForV8(isolate);
+
   if (FLAG_prof) {
     profiler_ = new Profiler(isolate);
     is_logging_ = true;
     profiler_->Engage();
+
+    // A way to to start profiler in pause mode was removed.
+    // To pause collection of the CPU ticks we need to emulate pause.
+    // This will be removed later once XDK agent will have own sampler.
+    profiler_->pause();
   }
 
   if (FLAG_log_internal_timer_events || FLAG_prof) timer_.Start();

--- a/src/log.h
+++ b/src/log.h
@@ -360,6 +360,13 @@ class Logger {
   // When data collection is paused, CPU Tick events are discarded.
   void StopProfiler();
 
+  // Resumes collection of CPU Tick events.
+  void XDKResumeProfiler();
+
+  // XDK agent uses it log code map (list of CodeAdded event
+  // before resume CPU Tick events.
+  Log* XDKGetLog() { return log_; }
+
   void LogExistingFunction(Handle<SharedFunctionInfo> shared,
                            Handle<Code> code);
   // Logs all compiled functions found in the heap.
@@ -528,15 +535,15 @@ class CodeEventLogger : public CodeEventListener {
   virtual void SharedFunctionInfoMoveEvent(Address from, Address to) { }
   virtual void CodeMovingGCEvent() { }
 
- private:
+ protected:
   class NameBuffer;
+  NameBuffer* name_buffer_;
 
+ private:
   virtual void LogRecordedBuffer(Code* code,
                                  SharedFunctionInfo* shared,
                                  const char* name,
                                  int length) = 0;
-
-  NameBuffer* name_buffer_;
 };
 
 

--- a/src/third_party/xdk/xdk-agent.cc
+++ b/src/third_party/xdk/xdk-agent.cc
@@ -1,0 +1,489 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xdk-agent.h"
+#include <vector>
+#include <string>
+#include <sstream>
+#include <sys/stat.h>
+#include "platform.h"
+#include "log-utils.h"
+
+namespace xdk {
+namespace internal {
+
+static unsigned int XDK_COMMAND_LENGTH = 100;  // It should be enough.
+
+// SetIdle has the same semantics as CpuProfiler::SetIdle has (v8/src/api.cc)
+// It is used to tell the sampler that XDK agent is idle (it is not busy with
+// some tasks). If the agent is idle that the sampler put a IDLE VM state into
+// the Tick record. The samples happen during IDLE will be attributed to (idle)
+// line in the XDK viewer.
+static void SetIdle(bool isIdle, v8engine::Isolate* isolate) {
+  CHECK(isolate);
+  v8engine::StateTag state = isolate->current_vm_state();
+  if (isolate->js_entry_sp() != NULL) return;
+  if (state == v8engine::EXTERNAL || state == v8engine::IDLE) {
+    if (isIdle) {
+      isolate->set_current_vm_state(v8engine::IDLE);
+    } else if (state == v8engine::IDLE) {
+      isolate->set_current_vm_state(v8engine::EXTERNAL);
+    }
+  }
+}
+
+
+bool XDKAgent::setUp(v8engine::Isolate* isolate) {
+  CHECK(isolate);
+
+  if (m_isolate) {
+    // The setUp method is called for the main thread first, then may be called
+    // again if the app uses Workers (each Worker object has own V8 instance).
+    // XDK agent does not support JavaScript Worker currently.
+    return false;
+  }
+
+  FILE* file = v8engine::OS::FOpen(XDK_MARKER_FILE, "r");
+  if (file != NULL) {
+    m_alive = true;
+    m_isolate = isolate;
+    fclose(file);
+  }
+
+  return m_alive;
+}
+
+
+void XDKAgent::resumeSampling() {
+  v8engine::LockGuard<v8engine::Mutex> l(m_agent_access);
+  CHECK(m_isolate);
+
+  v8engine::Log* log = m_isolate->logger()->XDKGetLog();
+  CHECK(log);
+
+  // Create a new log file for new profiling session
+  CHECK(!log->IsEnabled());
+  log->Initialize(XDK_TRACE_FILE);
+
+  int mode = S_IRUSR|S_IROTH|S_IRGRP|S_IWUSR|S_IWOTH|S_IWGRP;
+  if (chmod(XDK_TRACE_FILE, mode) != 0) {
+    XDK_LOG("xdk: Couldn't change permissions for a trace file\n");
+  }
+
+  CHECK(log->IsEnabled());
+
+  logFunctionSnapshot();
+
+  // Write a marker line into the log for testing purpose
+  v8engine::Log::MessageBuilder msg(log);
+  msg.Append("Profiler started.\n");
+  msg.WriteToLogFile();
+
+  // Resume collection the CPU Tick events
+  m_isolate->logger()->XDKResumeProfiler();
+  XDK_LOG("xdk: Sampling is resumed\n");
+
+  SetIdle(true, m_isolate);
+}
+
+
+void XDKAgent::pauseSampling() {
+  // Pause collection the CPU Tick events
+  CHECK(m_isolate);
+  m_isolate->logger()->StopProfiler();
+
+  // Use v8 logger internals to close the trace file.
+  // Once XDK agent implements own sampler this will be removed.
+  v8engine::Log* log = m_isolate->logger()->XDKGetLog();
+  CHECK(log);
+  log->stop();
+  log->Close();
+
+  XDK_LOG("xdk: Sampling is stopped\n");
+}
+
+
+struct ObjectDeallocator {
+  template<typename T>
+  void operator()(const T& obj) const { delete obj.second; }
+};
+
+
+XDKAgent::~XDKAgent() {
+  if (!m_alive) return;
+
+  CHECK(m_isolate);
+
+  m_terminate = true;
+  CHECK(m_server);
+
+  std::for_each(m_lineMaps.begin(), m_lineMaps.end(), ObjectDeallocator());
+  m_lineMaps.clear();
+
+  m_server->Shutdown();
+
+  Join();
+
+  delete m_server;
+}
+
+
+// The XDK listener thread.
+void XDKAgent::Run() {
+  v8engine::Isolate::EnsureDefaultIsolate();
+  v8engine::DisallowHeapAllocation no_allocation;
+  v8engine::DisallowHandleAllocation no_handles;
+  v8engine::DisallowHandleDereference no_deref;
+
+  XDK_LOG("xdk: Listener thread is running\n");
+  CHECK(m_server);
+
+  bool ok = m_server->Bind(m_port);
+  if (!ok) {
+    XDK_LOG("xdk: Unable to bind port=%d %d\n",
+            m_port, v8engine::Socket::GetLastError());
+    return;
+  }
+
+  char buf[XDK_COMMAND_LENGTH];
+
+  const std::string cmdStart = "start";
+  const std::string cmdStop = "stop";
+
+  while (!m_terminate) {
+    XDK_LOG("xdk: Listener thread is waiting for connection\n");
+
+    ok = m_server->Listen(1);
+    if (ok) {
+      v8engine::Socket* client = m_server->Accept();
+      if (client == NULL) {
+        XDK_LOG("xdk: Accept failed %d\n", v8engine::Socket::GetLastError());
+        continue;
+      }
+
+      XDK_LOG("xdk: Connected\n");
+
+      int bytes_read = client->Receive(buf, sizeof(buf) - 1);
+      if (bytes_read == 0) {
+        XDK_LOG("xdk: Receive failed %d\n", v8engine::Socket::GetLastError());
+        break;
+      }
+      buf[bytes_read] = '\0';
+
+  #ifdef WIN32
+      if (bytes_read > 3) buf[bytes_read - 2] = '\0';  // remove CR+LF symbols
+  #else
+      if (bytes_read > 2) buf[bytes_read - 1] = '\0';  // remove LF symbol
+  #endif
+
+      std::string clientCommand(&buf[0]);
+      XDK_LOG("xdk: Got '%s' profiling command\n", clientCommand.c_str());
+
+      if (clientCommand == cmdStart) {
+        resumeSampling();
+      } else if (clientCommand == cmdStop) {
+        pauseSampling();
+      } else {
+        XDK_LOG("xdk: '%s' is not handled command\n", clientCommand.c_str());
+        break;
+      }
+    }
+  }
+
+  XDK_LOG("xdk: Listener thread is stopped\n");
+  return;
+}
+
+
+void XDKAgent::processCodeMovedEvent(const v8::JitCodeEvent* event) {
+  v8engine::LockGuard<v8engine::Mutex> l(m_agent_access);
+  v8engine::Address from = static_cast<v8engine::Address>(event->code_start);
+  v8engine::Address to = static_cast<v8engine::Address>(event->new_code_start);
+
+  if (!from || !to) return;
+  XDK_LOG("xdk: CODE_MOVED from=0x%x to=0x%x\n", from, to);
+  m_snapshot.move(from, to);
+}
+
+
+void XDKAgent::processCodeRemovedEvent(const v8::JitCodeEvent* event) {
+  v8engine::LockGuard<v8engine::Mutex> l(m_agent_access);
+  v8engine::Address addr = static_cast<v8engine::Address>(event->code_start);
+
+  if (!addr) return;
+  XDK_LOG("xdk: CODE_REMOVED for addr=0x%x\n", addr);
+  m_snapshot.remove(addr);
+}
+
+
+static void getFunctionNameFromMixedName(
+  const char* str, int length, std::string& funcType, std::string& name) {
+  if (!str || !length) return;
+  name = "\"\"";  // default value
+
+  // log.cc CodeEventLogger::CodeCreateEvent overloaded members generate
+  // the string in one of the following forms
+  //
+  // [tag]:[comment]                    // Builtin:A builtin from the snapshot
+  // [tag]:[name]                       // KeyedStoreIC:
+  // [tag]:[name][marker][name]         // Script:~xwalk
+  // [tag]:[name][marker][name] [source]:line:column
+  // LazyCompile:~solve file:///data/previews/index.html:457:48
+  //
+  // Examples of original strings:
+  // code-creation,Stub,11,0x65a0a040,81,"BinaryOpStub"
+  // code-creation,LoadIC,5,0x65a0aec0,81,"A load IC from the snapshot"
+  // code-creation,Builtin,3,0x65a0af60,19,"A builtin from the snapshot"
+  // code-creation,LazyCompile,0,0x65a1cde0,240,
+  //                "InstallGetterSetter native v8natives.js:72:29",0x2d0108e4,
+  // code-creation,LazyCompile,0,0x65a1c4e0,508,
+  //                      "Instantiate native apinatives.js:44:21",0x2d023fac,~
+  //
+  // What need to be done?
+  // code-creation,Stub,,0x65a0a040,81,"BinaryOpStub"
+  // code-creation,LoadIC,,0x65a0aec0,81,"A load IC from the snapshot"
+  // code-creation,Builtin,,0x65a0af60,19,"A builtin from the snapshot"
+  // code-creation,LazyCompile,,0x65a1cde0,240,
+  //            "InstallGetterSetter native v8natives.js:72:29",linearcounter,*
+  // code-creation,LazyCompile,,0x65a1c4e0,508,"
+  //                    Instantiate native apinatives.js:44:21",linearcounter,*
+  //
+  // What missing?
+  // 3d  token - code->kind()
+  // 7th token - id.
+
+  // We use the linear counter instead of missing 7th token. It is OK to use
+  // static variable because this code is running in single thread.
+  static unsigned int i = 0;
+  std::string marker;
+  std::string tmp(str, length);
+
+  std::size_t index = tmp.find(':');
+  if (index == std::string::npos) return;
+  funcType = tmp.substr(0, index);
+  index++;
+
+  if (str[index] == '*' || str[index] == '~') {
+    marker = str[index];
+    index++;
+  }
+  if (index >= length) return;
+
+  std::stringstream ss;
+  ss << "\""
+     << std::string(const_cast<char*>(str + index), length - index) << "\"";
+  if (funcType == "LazyCompile") {
+    ss << ","  << std::dec << i++ << "," << marker;
+  }
+
+  name = ss.str();
+}
+
+
+void XDKAgent::processCodeAddedEvent(const v8::JitCodeEvent* event) {
+  v8engine::LockGuard<v8engine::Mutex> l(m_agent_access);
+
+  v8engine::Address codeAddr =
+    static_cast<v8engine::Address>(event->code_start);
+  uint32_t codeLen = event->code_len;
+
+  if (!codeAddr || !codeLen) return;
+  XDK_LOG("xdk: CODE_ADDED for addr=0x%x len=0x%x\n", codeAddr, codeLen);
+
+  // Look for line number information
+  LineMap* lineMap = NULL;
+  LineMaps::iterator itr = m_lineMaps.find(codeAddr);
+  if (itr == m_lineMaps.end()) {
+    XDK_LOG("xdk: Unable to find line info for addr=0x%x\n", codeAddr);
+  } else {
+    lineMap = itr->second;
+
+    // Remove line map if no chance to get source lines for it
+    v8::Handle<v8::Script> script = event->script;
+    if (*script == NULL) {
+      XDK_LOG("xdk: Script is empty. No line info for addr=0x%x.\n", codeAddr);
+      delete lineMap;
+      lineMap = NULL;
+      m_lineMaps.erase(codeAddr);
+    } else {
+      // Convert V8 pos value into source line number.
+      LineMap::Entries* entries =
+        const_cast<LineMap::Entries*>(lineMap->getEntries());
+      CHECK(entries);
+      CHECK(entries->size());
+      XDK_LOG("xdk: Found line info (%d lines) for addr=0x%x\n",
+              entries->size(), codeAddr);
+      size_t srcLine = 0;
+      LineMap::Entries::iterator lineItr = entries->begin();
+      LineMap::Entries::iterator lineEnd = entries->end();
+      for (lineItr; lineItr != lineEnd; ++lineItr) {
+        srcLine = script->GetLineNumber(lineItr->line) + 1;
+        lineItr->line = srcLine;
+        XDK_LOG("xdk:   offset=%p line=%d\n", lineItr->pcOffset, lineItr->line);
+      }
+    }
+  }
+
+  std::string funcType;
+  std::string name(event->name.str, event->name.len);
+  Function func(codeAddr, codeLen, name, funcType, lineMap);
+
+  if (lineMap) {
+    // Put the line number information for the given method into the trace file
+    // if profiling session is running.
+    logLineNumberInfo(codeAddr, *lineMap);
+
+    // Release memory allocated on CODE_START_LINE_INFO_RECORDING
+    delete lineMap;
+    lineMap = NULL;
+    m_lineMaps.erase(codeAddr);
+  }
+
+  m_snapshot.insert(func);
+}
+
+
+void XDKAgent::processLineMapAddedEvent(const v8::JitCodeEvent* event) {
+  v8engine::LockGuard<v8engine::Mutex> l(m_agent_access);
+  v8engine::Address codeAddr =
+    static_cast<v8engine::Address>(event->code_start);
+  void* userData = event->user_data;
+
+  if (!userData || !codeAddr) return;
+
+  LineMap* lineMap = reinterpret_cast<LineMap*>(userData);
+  if (lineMap->getSize() == 0) {
+    XDK_LOG("xdk: CODE_END_LINE no entries for user_data=%p addr=0x%x\n",
+            userData, codeAddr);
+    return;
+  }
+
+  std::pair<LineMaps::iterator, bool>
+    result = m_lineMaps.insert(std::make_pair(codeAddr, lineMap));
+  if (!result.second) {
+    m_lineMaps.erase(codeAddr);
+    XDK_LOG("xdk: removed unprocessed line info for addr=0x%x\n", codeAddr);
+    result = m_lineMaps.insert(std::make_pair(codeAddr, lineMap));
+    CHECK(result.second);
+  }
+
+  XDK_LOG("xdk: CODE_END_LINE added %d entries for user_data=%p addr=0x%x\n",
+           lineMap->getSize(), userData, codeAddr);
+}
+
+
+void EventHandler(const v8::JitCodeEvent* event) {
+  // This callback is called regardless of whether profiling is running.
+  //
+  // By default profiling is launched in paused mode, the agent is awaiting
+  // a command to resume profiling. At the same time, V8's JIT compiler is
+  // working. The functions which are JIT-compiled while sampling is paused
+  // are cached by V8's Logger and will be written in log (trace file) when
+  // XDK resumes the profiling. The line number info for such functions are not
+  // cached. We need to capture and cache the line number info and flush
+  // the cache on resume profiling.
+
+  if (event == NULL) return;
+
+  switch (event->type) {
+    case v8::JitCodeEvent::CODE_MOVED:
+      XDKAgent::instance().processCodeMovedEvent(event);
+      break;
+
+    case v8::JitCodeEvent::CODE_REMOVED:
+      XDKAgent::instance().processCodeRemovedEvent(event);
+      break;
+
+    case v8::JitCodeEvent::CODE_ADDED:
+      XDKAgent::instance().processCodeAddedEvent(event);
+
+    case v8::JitCodeEvent::CODE_ADD_LINE_POS_INFO: {
+      void* userData = event->user_data;
+      if (!userData) return;
+      LineMap* lineMap = reinterpret_cast<LineMap*>(userData);
+      size_t offset = event->line_info.offset;
+      size_t pos = event->line_info.pos;
+      lineMap->setPosition(offset, pos);
+      XDK_LOG("xdk: CODE_ADD_LINE_POS for user_data=%p offset=0x%x pos=%d\n",
+               userData, offset, pos);
+      break;
+    }
+
+    case v8::JitCodeEvent::CODE_START_LINE_INFO_RECORDING: {
+      v8::JitCodeEvent* data = const_cast<v8::JitCodeEvent*>(event);
+      data->user_data = new LineMap();
+      XDK_LOG("xdk: CODE_START_LINE for user_data=%p\n", event->user_data);
+      break;
+    }
+
+    case v8::JitCodeEvent::CODE_END_LINE_INFO_RECORDING: {
+      XDKAgent::instance().processLineMapAddedEvent(event);
+      break;
+    }
+
+    default:
+      XDK_LOG("xdk: Unknown event\n");
+      break;
+  }
+
+  SetIdle(true, XDKAgent::instance().isolate());
+
+  return;
+}
+
+
+void XDKAgent::logLineNumberInfo(v8engine::Address addr,
+                                 const LineMap& lineInfo) {
+  CHECK(addr);
+  v8engine::Log* log = m_isolate->logger()->XDKGetLog();
+  CHECK(log);
+  if (!log->IsEnabled()) return;
+  if (lineInfo.getSize() == 0) return;
+  const LineMap::Entries* lines = lineInfo.getEntries();
+  CHECK(lines);
+  LineMap::Entries::const_iterator lineItr = lines->begin();
+  LineMap::Entries::const_iterator lineEnd = lines->end();
+
+  // Put 'src-pos' lines into the log in our own format
+  for (lineItr; lineItr != lineEnd; ++lineItr) {
+    v8engine::Log::MessageBuilder msg(m_isolate->logger()->XDKGetLog());
+    msg.Append("src-pos,");
+    msg.Append("0x%x,%d,%d\n", addr, lineItr->pcOffset, lineItr->line);
+    msg.WriteToLogFile();
+  }
+}
+
+
+void XDKAgent::logFunctionSnapshot() {
+  CHECK(m_isolate);
+
+  CodeMap::const_iterator funcItr = m_snapshot.entries().begin();
+  CodeMap::const_iterator funcEnd = m_snapshot.entries().end();
+
+  XDK_LOG("FunctionSnapshot: %d entries\n", m_snapshot.entries().size());
+  if (m_snapshot.entries().size() == 0) return;
+
+  unsigned int i = 1;
+
+  for (funcItr; funcItr != funcEnd; ++funcItr, i++) {
+    const Range& range = funcItr->first;
+    const Function& func = funcItr->second;
+
+    XDK_LOG("%d    %s\n", i, func.getLogLine().c_str());
+
+    const LineMap& map = func.getLineMap();
+    if (map.getSize()) {
+      v8engine::Address codeAddr = range.start();
+      XDK_LOG("  Found %d lines for addr=%p\n", map.getSize(), codeAddr);
+      logLineNumberInfo(codeAddr, map);
+    }
+
+    // Write 'code-creation' line into the log
+    v8engine::Log::MessageBuilder msg(m_isolate->logger()->XDKGetLog());
+    msg.Append("%s\n", func.getLogLine().c_str());
+    msg.WriteToLogFile();
+  }
+}
+
+}}  // namespace xdk::internal

--- a/src/third_party/xdk/xdk-agent.h
+++ b/src/third_party/xdk/xdk-agent.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XDK_AGENT_H_
+#define XDK_AGENT_H_
+
+#include "v8.h"
+#include "sampler.h"
+#include "platform.h"
+#include "platform/socket.h"
+#include "platform/mutex.h"
+#include "xdk-types.h"
+#include "xdk-code-map.h"
+
+// ----------------------------------------------------------------------------
+//
+// This file declares XDKAgent class which does
+//
+// - Handles the code events to maintain the code map.
+// - Handles the line info events to assosiate the line info with code event.
+// - Accepts start / stop profiling commands from AppAnalyzer.
+//
+// ----------------------------------------------------------------------------
+
+namespace xdk {
+namespace internal {
+
+const int XDK_AGENT_PORT = 48899;
+
+static const char* XDK_TRACE_FILE =
+  "/data/data/com.intel.app_analyzer/files/result.xdk2v8";
+static const char* XDK_MARKER_FILE =
+  "/data/data/com.intel.app_analyzer/files/profiler.run";
+
+// Callback called by V8 builtin logger.
+void EventHandler(const v8::JitCodeEvent* event);
+
+// XDK profiling agent. It starts a socket listener on the specific port and
+// handles commands to start and stop sampling.
+class XDKAgent : public v8engine::Thread {
+ public:
+  static XDKAgent& instance() {
+    static XDKAgent instance;
+    return instance;
+  }
+
+  void Run();
+
+  bool setUp(v8engine::Isolate* isolate);
+
+  void processCodeMovedEvent(const v8::JitCodeEvent* event);
+  void processCodeRemovedEvent(const v8::JitCodeEvent* event);
+  void processCodeAddedEvent(const v8::JitCodeEvent* event);
+  void processLineMapAddedEvent(const v8::JitCodeEvent* event);
+
+  inline v8engine::Isolate* isolate() { return m_isolate; }
+
+ private:
+  virtual ~XDKAgent();
+  XDKAgent()
+      : v8engine::Thread("xdk:agent"),
+        m_port(XDK_AGENT_PORT),
+        m_agent_access(new v8engine::Mutex()),
+        m_server(new v8engine::Socket()),
+        m_terminate(false),
+        m_alive(false),
+        m_isolate(NULL) {
+  }
+  XDKAgent(const XDKAgent&);
+  XDKAgent& operator=(const XDKAgent&);
+
+  void logFunctionSnapshot();
+  void logLineNumberInfo(v8engine::Address codeAddr, const LineMap& lineInfo);
+
+  void resumeSampling();
+  void pauseSampling();
+
+  bool m_alive;
+
+  const int m_port;  // Port to use for the agent.
+  v8engine::Socket* m_server;  // Server socket for listen/accept.
+  v8engine::Mutex* m_agent_access;
+  v8engine::Isolate* m_isolate;
+
+  // The snapshot of compiled methods at present moment.
+  FunctionSnapshot m_snapshot;
+
+  // The processLineMapAddedEvent function adds a new map for code starting
+  // address. Newly added map describes how ps offsets maps to internal pos,
+  // but not how ps offsets maps to line number within source file.
+  //
+  // On CodeAdd event, processCodeAddedEvent function looks for line map for
+  // a code address. If map is found that assign it to a object of Function type
+  // in FunctionSnapshot. Before assign the pc offset to pos map is converted
+  // to pc offset to source line.
+  //
+  // CodeMoved and CodeRemoved must not affect this map.
+  // Current understanding of V8 code generator: V8 first emits LineStart event,
+  // then bunch of LineAdd events, then LineEnd event, finally CodeAdded event.
+  // Based on above no need to add any 'smart' logic on CodeMoved and
+  // CodeRemoved for line map.
+  //
+  // Basically it should be always empty.
+  LineMaps m_lineMaps;
+
+  bool m_terminate;  // Termination flag for listening thread.
+};
+
+} }  // namespace xdk::internal
+
+#endif  // XDK_AGENT_H_

--- a/src/third_party/xdk/xdk-code-map.cc
+++ b/src/third_party/xdk/xdk-code-map.cc
@@ -1,0 +1,145 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "xdk-code-map.h"
+#include <sstream>
+
+namespace xdk {
+namespace internal {
+
+static std::string replaceAddress(const std::string& str,
+                                  v8engine::Address addr) {
+  // The input str: code-creation,LazyCompile,0,0x3851c4e0,200," native uri.js"
+  std::string first;
+  std::string end;
+
+  std::size_t found = str.find(',');
+  if (found != std::string::npos) {
+    found = str.find(',', found + 1);
+    if (found != std::string::npos) {
+      found = str.find(',', found + 1);
+      if (found != std::string::npos) {
+        first = str.substr(0, found);
+        found = str.find(',', found + 1);
+        if (found != std::string::npos) {
+          end = str.substr(found, str.size() - found);
+        }
+      }
+    }
+  }
+
+  if (!first.size() || !end.size()) return str;
+
+  std::stringstream ss;
+  ss << first << ','
+     << std::showbase << std::hex << static_cast<void*>(addr) << end;
+  return ss.str();
+}
+
+
+Function::Function(v8engine::Address codeAddr, uint32_t codeLen,
+                   const std::string& name, const std::string& type,
+                   const LineMap* lineMap)
+    : m_codeAddr(codeAddr), m_codeLen(codeLen), m_name(name), m_type(type) {
+  CHECK(codeAddr);
+  CHECK(codeLen);
+  // Can't be empty because it's came from CodeCreation(...) events
+  CHECK(!name.empty());
+  m_logLine = m_name;
+
+  if (lineMap && lineMap->getSize()) m_lineMap = *lineMap;
+}
+
+
+void FunctionSnapshot::removeAll(const Range& range) {
+  CodeMap::iterator low = m_impl.lower_bound(range);
+  CodeMap::iterator up = m_impl.upper_bound(range);
+  CodeMap::iterator::difference_type num = std::distance(low, up);
+
+  if (num) {
+    XDK_LOG("xdk: %d ranges were overlapped and removed\n", num);
+
+    CodeMap::iterator itr = low;
+    for (itr; itr != up; ++itr) {
+      XDK_LOG("xdk:  ovrl&removed addr=0x%x len=0x%x name=%s\n",
+              itr->first.start(), itr->first.length(),
+              itr->second.getLogLine().c_str());
+    }
+    m_impl.erase(low, up);
+  }
+}
+
+
+void FunctionSnapshot::insert(const Function& func) {
+  v8engine::Address codeAddr = func.getCodeAddress();
+  uint32_t codeLen = func.getCodeLength();
+  CHECK(codeAddr);
+  CHECK(codeLen);
+
+  Range range(codeAddr, codeLen);
+
+  removeAll(range);
+
+  std::pair<CodeMap::iterator, bool> res =
+    m_impl.insert(std::make_pair(range, func));
+  CHECK(res.second);
+
+  XDK_LOG("xdk: size=%d added addr=0x%x name=%s\n",
+          m_impl.size(), range.start(), func.getLogLine().c_str());
+}
+
+
+void FunctionSnapshot::remove(v8engine::Address codeAddr) {
+  if (!codeAddr) return;
+  CodeMap::iterator itr = m_impl.find(Range(codeAddr, 1));
+  if (itr != m_impl.end()) {
+    std::string name = itr->second.getLogLine();
+    uint32_t len = itr->first.length();
+    m_impl.erase(itr);
+    XDK_LOG("xdk: size=%d removed addr=0x%x name=%s\n",
+             m_impl.size(), codeAddr, len, name.c_str());
+  }
+}
+
+
+void FunctionSnapshot::move(v8engine::Address from, v8engine::Address to) {
+  if (!from || !to) return;
+  if (from == to) return;
+
+  CodeMap::iterator itr = m_impl.find(Range(from, 1));
+  if (itr == m_impl.end()) {
+    XDK_LOG("xdk: couldn't find a code to move from=0x%x to=0x%x\n", from, to);
+    return;
+  }
+  if (itr->first.start() != from) {
+    XDK_LOG("xdk: discarded move from=0x%x to=0x%x\n", from, to);
+    return;
+  }
+
+  uint32_t codeLen = itr->second.getCodeLength();
+  const LineMap& lines = itr->second.getLineMap();
+
+  // In case of CodeMoved we have to check that name contains the same code
+  // addr and code length as the input params and replace if they are different.
+  const std::string& orig = itr->second.getName();
+  std::string name = replaceAddress(orig, to);
+
+  const std::string& type = itr->second.getType();
+  Function toEntry(to, codeLen, name, type, &lines);
+
+  m_impl.erase(itr);
+
+  Range range(to, codeLen);
+  removeAll(range);
+
+  // Now ready to move
+
+  bool ok = m_impl.insert(std::make_pair(range, toEntry)).second;
+  CHECK(ok);
+
+  XDK_LOG("xdk: size=%d moved from=0x%x to=0x%x name=%s\n",
+           m_impl.size(), from, to, toEntry.getLogLine().c_str());
+}
+
+} }  // namespace xdk::internal

--- a/src/third_party/xdk/xdk-code-map.h
+++ b/src/third_party/xdk/xdk-code-map.h
@@ -1,0 +1,134 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XDK_CODE_MAP_H_
+#define XDK_CODE_MAP_H_
+
+// ----------------------------------------------------------------------------
+//
+// This file contains the FunctionSnapshot and related objects declarations
+//
+// The FunctionSnapshot object maintains a map of JIT compiled functions.
+// It is modified on code events(CodeAdded, CodeMoved and CodeDeleted) from
+// V8 built-in profiler.
+//
+// ----------------------------------------------------------------------------
+
+#include "xdk-types.h"
+#include <map>
+#include <list>
+#include <string>
+#include <algorithm>
+
+namespace xdk {
+namespace internal {
+
+class LineMap;
+typedef std::map<
+          v8engine::Address,  // start address of code
+          LineMap*> LineMaps;
+
+// This class is used to record the JITted code position info for JIT
+// code profiling.
+class LineMap {
+ public:
+  struct LineEntry {
+    LineEntry(size_t offset, size_t line)
+      : pcOffset(offset), line(line) { }
+
+    size_t pcOffset;  // PC offset from the begining of the code trace.
+    size_t line;      // Can be either position returned from V8 assembler
+                      // (which needs to be converted to src line) or src line
+                      // number.
+  };
+
+  typedef std::list<LineEntry> Entries;
+
+  void setPosition(size_t offset, size_t line) {
+    addCodeLineEntry(LineEntry(offset, line));
+  }
+
+  inline size_t getSize() const { return m_lines.size(); }
+  const Entries* getEntries() const { return &m_lines; }
+
+ private:
+  void addCodeLineEntry(const LineEntry& entry) { m_lines.push_back(entry); }
+
+  Entries m_lines;
+};
+
+// This class describes the function reported with CodeAdded event.
+class Function {
+ public:
+  explicit Function(v8engine::Address codeAddr, uint32_t codeLen,
+                    const std::string& name, const std::string& type,
+                    const LineMap* lineMap);
+
+  inline v8engine::Address getCodeAddress() const { return m_codeAddr; }
+  inline uint32_t getCodeLength() const { return m_codeLen; }
+
+  inline const std::string& getType() const { return m_type; }
+  inline const std::string& getName() const { return m_name; }
+  inline const std::string& getLogLine() const { return m_logLine; }
+
+  const LineMap& getLineMap() const { return m_lineMap; }
+
+ private:
+  v8engine::Address m_codeAddr;
+  uint32_t m_codeLen;
+  std::string m_name;
+  std::string m_type;
+  std::string m_logLine;
+  LineMap m_lineMap;
+};
+
+// This class describes the code range related to object of Function type.
+// The start address and length are taken from CodeAdded event.
+class Range {
+ public:
+  class Comparator : public std::binary_function<Range&, Range&, bool> {
+   public:
+     bool operator()(const Range& l, const Range& r) const {
+       return (l.start() + l.length() <= r.start());
+     }
+  };
+
+  Range(v8engine::Address start, uint32_t length)
+    : m_start(start), m_length(length) { }
+
+  inline v8engine::Address start() const { return m_start; }
+  inline uint32_t length() const { return m_length; }
+
+ private:
+  v8engine::Address m_start;
+  uint32_t m_length;
+};
+
+// This class maintains a map of JIT compiled functions.
+// The content is changed on CodeAdded, CodeMoved and CodeDeleted events.
+typedef std::map<Range, const Function, Range::Comparator> CodeMap;
+
+class FunctionSnapshot {
+ public:
+  explicit FunctionSnapshot() {}
+  virtual ~FunctionSnapshot() { m_impl.clear(); }
+
+  void insert(const Function& func);
+  void move(v8engine::Address from, v8engine::Address to);
+  void remove(v8engine::Address addr);
+
+  inline const CodeMap& entries() { return m_impl; }
+
+ private:
+  FunctionSnapshot(const FunctionSnapshot&);
+  FunctionSnapshot& operator=(const FunctionSnapshot&);
+
+  void removeAll(const Range& range);
+
+  CodeMap m_impl;
+};
+
+} }  // namespace xdk::internal
+
+#endif  // XDK_CODE_MAP_H_

--- a/src/third_party/xdk/xdk-types.h
+++ b/src/third_party/xdk/xdk-types.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XDK_TYPES_H_
+#define XDK_TYPES_H_
+
+#include "v8.h"
+
+namespace v8engine = v8::internal;
+
+#if DEBUG
+#define XDK_LOG v8engine::PrintF
+#else
+#define XDK_LOG
+#endif
+
+#endif  // XDK_TYPES__H_
+

--- a/src/third_party/xdk/xdk-v8.cc
+++ b/src/third_party/xdk/xdk-v8.cc
@@ -1,0 +1,27 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "../../../include/v8.h"
+#include "xdk-v8.h"
+#include "xdk-agent.h"
+
+namespace xdk {
+
+void XDKInitializeForV8(v8::internal::Isolate* isolate) {
+  if (!internal::XDKAgent::instance().setUp(isolate)) return;
+
+  XDK_LOG("xdk: XDKInitializeForV8\n");
+
+  // The --prof flag is requred for now to enable the CPU ticks collection.
+  // This flag will be removed once xdk agent implements own sampler.
+  const char* flags = "--prof";
+  v8::V8::SetFlagsFromString(flags, static_cast<int>(strlen(flags)));
+
+  v8::V8::SetJitCodeEventHandler(v8::kJitCodeEventDefault,
+                                 xdk::internal::EventHandler);
+
+  internal::XDKAgent::instance().Start();
+}
+
+}  // namespace xdk

--- a/src/third_party/xdk/xdk-v8.gyp
+++ b/src/third_party/xdk/xdk-v8.gyp
@@ -1,0 +1,42 @@
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+{
+  'variables': {
+    'v8_code': 1,
+   },
+  'includes': ['../../../build/toolchain.gypi', '../../../build/features.gypi'],
+  'targets': [
+    {
+      'target_name': 'v8_xdk',
+      'type': 'static_library',
+      'conditions': [
+        ['want_separate_host_toolset==1', {
+          'toolsets': ['host', 'target'],
+        }, {
+          'toolsets': ['target'],
+        }],
+      ],
+      'include_dirs+': [
+        '../../',
+      ],
+      'sources': [
+        'xdk-v8.h',
+        'xdk-v8.cc',
+        'xdk-agent.h',
+        'xdk-agent.cc',
+        'xdk-code-map.h',
+        'xdk-code-map.cc',
+        'xdk-types.h',
+      ],
+      'direct_dependent_settings': {
+        'conditions': [
+          ['OS != "win"', {
+            'libraries': ['-ldl',],
+          }],
+        ],
+      },
+    },
+  ]
+}

--- a/src/third_party/xdk/xdk-v8.h
+++ b/src/third_party/xdk/xdk-v8.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_XDK_H_
+#define V8_XDK_H_
+
+// ----------------------------------------------------------------------------
+//
+//                          XDK profiling support for V8
+//
+//  SOURCES:
+//
+//  1. XDK agent source files are located in v8/src/third_party/xdk folder.
+//
+//       To integrate this stuff into V8 build system you need to modify
+//       two v8 files:
+//
+//       1. v8/build/features.gypi
+//           'v8_enable_xdkprof': 1,
+//       2. v8/tools/gyp/v8.gyp
+//           ['v8_enable_xdkprof==1', {
+//             'dependencies': ['../../src/third_party/xdk/xdk-v8.gyp:v8_xdk',],
+//           }],
+//
+//  2. Two V8 files v8/src/log.cc and v8/src/log.h need to be modified
+//
+//       The changes related to start CPU ticks collection using V8 built-in
+//       profiler.
+//       We are working on reduce these changes up to 2 lines:
+//
+//           #include "third_party/xdk/xdk-v8.h"
+//           bool Logger::SetUp(Isolate* isolate) {
+//             ...
+//             xdk::XDKInitializeForV8(isolate);
+//             ...
+//           }
+//
+//  OVERVIEW:
+//
+//  Start up
+//
+//    XDK agent is initialized as a part of V8 built-in profiler on process
+//    start up. V8 built-in profiler should be paused (CPU ticks are not
+//    collected).
+//
+//           v8/src/log.cc:
+//           bool Logger::SetUp(Isolate* isolate) {
+//             ...
+//             xdk::XDKInitializeForV8(isolate);
+//             ...
+//           }
+//
+//      XDKInitializeForV8() function
+//      1. Checks whether XDK agent can be initialized. If a marker file is not
+//         found that initialization will be discarded.
+//      2. Starts a listener thread to accept start / stop profiling command
+//         from AppAnalyzer (xdk/xdk-agent.cc).
+//      3. Registeres a callback to consume the CodeAdded, CodeMoved,
+//         CodeDeleted events and events related to source line info by
+//         the agent.
+//
+//  Runtime
+//
+//    XDK profiler consumes the code events (EventHandler() in xdk/xdk-agent.cc)
+//    V8 emits these events even when CPU ticks collection is paused.
+//    The profiler uses the code events to maintain a function snapshot (list of
+//    code ranges assosiated with function name and source line info)
+//    (xdk-code-map.cc).
+//
+//    Start profiling
+//
+//      When the profiler receives a command to start profiling that it calls
+//      resumeSampling() (xdk/xdk-agent.cc) which
+//      1. Creates a new trace file to log the ticks and code events
+//      2. Puts the function snapshot into the trace file
+//      3. Resumes CPU ticks collection
+//
+//    Stop profiling
+//
+//      When the profiler receives a command to stop profiling that it calls
+//      pauseSampling() (xdk/xdk-agent.cc) which stops the CPU ticks collection.
+//      Note that the agent continues to consume the code events to maintain
+//      the function snapshot.
+//
+//      When collection is stopped that AppAnalyzer takes the trace file for
+//      processing.
+//
+// ----------------------------------------------------------------------------
+
+namespace xdk {
+
+// This function
+// - Overrides the V8 flags to specify a new logfile for writting profiling data
+//   (CPU ticks and Code* events).
+// - Registers callback to get line number info and code events from V8 built-in
+//   profiler. These data are needed to mantain the code map.
+// - Starts the XDK agent listener thread which is awaiting for start and stop
+//   profiling commands.
+void XDKInitializeForV8(v8::internal::Isolate* isolate);
+
+}  // namespace XDK
+
+#endif  // V8_XDK_H_
+

--- a/tools/gyp/v8.gyp
+++ b/tools/gyp/v8.gyp
@@ -611,6 +611,9 @@
         }, {
           'toolsets': ['target'],
         }],
+       ['v8_enable_xdkprof==1', {
+          'dependencies': ['../../src/third_party/xdk/xdk-v8.gyp:v8_xdk',],
+        }],
         ['v8_target_arch=="arm"', {
           'sources': [  ### gcmole(arch:arm) ###
             '../../src/arm/assembler-arm-inl.h',


### PR DESCRIPTION
This is the same patch as we already applied for Chromium v32 with minor differences in Logger::LogCodeObjects() and Logger::LogCompiledFunctions() from log.cc.
This patch enables CPU profiling feature for XDK.
