### PR TITLE
[Temp] Backport r21402 from the bleeding_edge branch.

### DIFF
--- a/test/promises-aplus/testcfg.py
+++ b/test/promises-aplus/testcfg.py
@@ -31,9 +31,9 @@ import os
 import shutil
 import sys
 import tarfile
-import urllib
 
 from testrunner.local import testsuite
+from testrunner.local import utils
 from testrunner.objects import testcase
 
 
@@ -102,7 +102,7 @@ class PromiseAplusTestSuite(testsuite.TestSuite):
     directory = os.path.join(self.root, TEST_NAME)
     if not os.path.exists(archive):
       print('Downloading {0} from {1} ...'.format(TEST_NAME, TEST_URL))
-      urllib.urlretrieve(TEST_URL, archive)
+      utils.URLRetrieve(TEST_URL, archive)
       if os.path.exists(directory):
         shutil.rmtree(directory)
 
@@ -129,7 +129,7 @@ class PromiseAplusTestSuite(testsuite.TestSuite):
       os.mkdir(directory)
     path = os.path.join(directory, SINON_FILENAME)
     if not os.path.exists(path):
-      urllib.urlretrieve(SINON_URL, path)
+      utils.URLRetrieve(SINON_URL, path)
     hash = hashlib.sha256()
     with open(path, 'rb') as f:
       for chunk in iter(lambda: f.read(8192), ''):

--- a/test/test262/testcfg.py
+++ b/test/test262/testcfg.py
@@ -31,9 +31,9 @@ import os
 import shutil
 import sys
 import tarfile
-import urllib
 
 from testrunner.local import testsuite
+from testrunner.local import utils
 from testrunner.objects import testcase
 
 
@@ -97,7 +97,7 @@ class Test262TestSuite(testsuite.TestSuite):
     directory_old_name = os.path.join(self.root, "data.old")
     if not os.path.exists(archive_name):
       print "Downloading test data from %s ..." % archive_url
-      urllib.urlretrieve(archive_url, archive_name)
+      utils.URLRetrieve(archive_url, archive_name)
       if os.path.exists(directory_name):
         if os.path.exists(directory_old_name):
           shutil.rmtree(directory_old_name)

--- a/tools/testrunner/local/utils.py
+++ b/tools/testrunner/local/utils.py
@@ -32,6 +32,7 @@ from os.path import isdir
 from os.path import join
 import platform
 import re
+import urllib2
 
 
 def GetSuitePaths(test_root):
@@ -113,3 +114,10 @@ def GuessWordsize():
 
 def IsWindows():
   return GuessOS() == 'windows'
+
+
+def URLRetrieve(source, destination):
+  """urllib is broken for SSL connections via a proxy therefore we
+  can't use urllib.urlretrieve()."""
+  with open(destination, 'w') as f:
+    f.write(urllib2.urlopen(source).read())


### PR DESCRIPTION
Original commit message:

> Stop using urllib.urlretrieve() directly.
> 
> Using urllib for SSL connections when behind a proxy is known to be
> broken, so apply the same fix from depot_tools r149742 and use a wrapper
> around urllib2 instead.
> 
> R=jkummerow@chromium.org
> TEST=run test262 behind corporate proxy
> 
> Review URL: https://codereview.chromium.org/297663003
> 
> Patch from Raphael Kubo da Costa raphael.kubo.da.costa@intel.com.

This is necessary for the test262 tests to pass inside the network our
v8-crosswalk bots run in.
