### PR TITLE
Set kTruncatingToInt32 flag if one of the SIMD operand requires Integer32

### DIFF
--- a/src/hydrogen-instructions.h
+++ b/src/hydrogen-instructions.h
@@ -7785,6 +7785,9 @@ SIMD_UNARY_OPERATIONS_FOR_PROPERTY_ACCESS(SIMD_UNARY_OPERATION_CASE_ITEM)
       case k##name:                                                       \
         set_representation(Representation::representation());             \
         set_type(HType::TypeFromRepresentation(representation_));         \
+        if (Representation::p5().IsInteger32())  {                        \
+          SetFlag(kTruncatingToInt32);                                    \
+        }                                                                 \
         break;
 SIMD_UNARY_OPERATIONS(SIMD_UNARY_OPERATION_CASE_ITEM)
 SIMD_UNARY_OPERATIONS_FOR_PROPERTY_ACCESS(SIMD_UNARY_OPERATION_CASE_ITEM)
@@ -7858,6 +7861,10 @@ SIMD_BINARY_OPERATIONS(SIMD_BINARY_OPERATION_CASE_ITEM)
       case k##name:                                                            \
         set_representation(Representation::representation());                  \
         set_type(HType::TypeFromRepresentation(representation_));              \
+        if (Representation::p5().IsInteger32() ||                              \
+            Representation::p6().IsInteger32())  {                             \
+          SetFlag(kTruncatingToInt32);                                         \
+        }                                                                      \
         break;
 SIMD_BINARY_OPERATIONS(SIMD_BINARY_OPERATION_CASE_ITEM)
 #undef SIMD_BINARY_OPERATION_CASE_ITEM
@@ -7939,6 +7946,11 @@ SIMD_TERNARY_OPERATIONS(SIMD_TERNARY_OPERATION_CASE_ITEM)
       case k##name:                                                            \
         set_representation(Representation::representation());                  \
         set_type(HType::TypeFromRepresentation(representation_));              \
+        if (Representation::p5().IsInteger32() ||                              \
+            Representation::p6().IsInteger32() ||                              \
+            Representation::p7().IsInteger32())  {                             \
+          SetFlag(kTruncatingToInt32);                                         \
+        }                                                                      \
         break;
 SIMD_TERNARY_OPERATIONS(SIMD_TERNARY_OPERATION_CASE_ITEM)
 #undef SIMD_TERNARY_OPERATION_CASE_ITEM
@@ -8025,6 +8037,12 @@ SIMD_QUARTERNARY_OPERATIONS(SIMD_QUARTERNARY_OPERATION_CASE_ITEM)
       case k##name:                                                            \
         set_representation(Representation::representation());                  \
         set_type(HType::TypeFromRepresentation(representation_));              \
+        if (Representation::p5().IsInteger32() ||                              \
+            Representation::p6().IsInteger32() ||                              \
+            Representation::p7().IsInteger32() ||                              \
+            Representation::p8().IsInteger32())  {                             \
+          SetFlag(kTruncatingToInt32);                                         \
+        }                                                                      \
         break;
 SIMD_QUARTERNARY_OPERATIONS(SIMD_QUARTERNARY_OPERATION_CASE_ITEM)
 #undef SIMD_QUARTERNARY_OPERATION_CASE_ITEM


### PR DESCRIPTION
Before this, we deoptimize for SIMD.int32x4.splat(0x80000000) and
SIMD.int32x4(0x80000000, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF) as we did
not truncate the "double/unsigned int32" to signed int32. It seems OK to
set kTruncatingToInt32 flag in a general way so it works for int32x4
shift and shuffle operation also.
