### PR TITLE
CDT CPU profiler: source info support

### DIFF
--- a/include/v8-profiler.h
+++ b/include/v8-profiler.h
@@ -17,6 +17,14 @@ struct HeapStatsUpdate;
 
 typedef uint32_t SnapshotObjectId;
 
+typedef struct {
+  /** The 1-based number of the source line where the function originates. */
+  unsigned int line;
+
+  /** The count of samples associated with the source line. */
+  unsigned int ticks;
+} LineTick;
+
 /**
  * CpuProfileNode represents a node in a call graph.
  */
@@ -42,6 +50,17 @@ class V8_EXPORT CpuProfileNode {
    * kNoColumnNumberInfo if no column number information is available.
    */
   int GetColumnNumber() const;
+
+  /**
+   * Returns the number of the function's source lines that collect the samples.
+   */
+   unsigned int GetHitLineCount() const;
+
+  /** Returns the set of source lines that collect the samples.
+   *  The caller allocates buffer and responsible for releasing it.
+   *  True if all available entries are copied, otherwise false.
+   */
+  bool GetLineTicks(LineTick* entries, unsigned int number) const;
 
   /** Returns bailout reason for the function
     * if the optimization was disabled for it.

--- a/src/api.cc
+++ b/src/api.cc
@@ -6996,6 +6996,19 @@ int CpuProfileNode::GetColumnNumber() const {
 }
 
 
+unsigned int CpuProfileNode::GetHitLineCount() const {
+  const i::ProfileNode* node = reinterpret_cast<const i::ProfileNode*>(this);
+  return node->GetHitLineCount();
+}
+
+
+bool CpuProfileNode::GetLineTicks(LineTick* entries,
+                                  unsigned int number) const {
+  const i::ProfileNode* node = reinterpret_cast<const i::ProfileNode*>(this);
+  return node->GetLineTicks(entries, number);
+}
+
+
 const char* CpuProfileNode::GetBailoutReason() const {
   const i::ProfileNode* node = reinterpret_cast<const i::ProfileNode*>(this);
   return node->entry()->bailout_reason();

--- a/src/cpu-profiler.cc
+++ b/src/cpu-profiler.cc
@@ -257,17 +257,33 @@ void CpuProfiler::CodeCreateEvent(Logger::LogEventsAndTags tag,
   CodeEventsContainer evt_rec(CodeEventRecord::CODE_CREATION);
   CodeCreateEventRecord* rec = &evt_rec.CodeCreateEventRecord_;
   rec->start = code->address();
+  // Get line info from the relocation information.
+  ASSERT(Script::cast(shared->script()));
+  JITLineInfoTable line_table;
+  if (line > 0) {
+    for (RelocIterator it(code); !it.done(); it.next()) {
+      RelocInfo::Mode mode = it.rinfo()->rmode();
+      if (RelocInfo::IsPosition(mode)) {
+        int pc_offset = static_cast<int>(it.rinfo()->pc() - code->address());
+        int position = static_cast<int>(it.rinfo()->data());
+        int lineno = Script::cast(shared->script())->GetLineNumber(position) + 1;
+        if (position >= 0 && lineno > 0) {
+          line_table.SetPosition(pc_offset, lineno);
+        }
+      }
+    }
+  }
   rec->entry = profiles_->NewCodeEntry(
       tag,
       profiles_->GetFunctionName(shared->DebugName()),
       CodeEntry::kEmptyNamePrefix,
       profiles_->GetName(source),
       line,
-      column);
+      column,
+      line_table.entries()->length() ? &line_table : NULL);
   if (info) {
     rec->entry->set_no_frame_ranges(info->ReleaseNoFrameRanges());
   }
-  ASSERT(Script::cast(shared->script()));
   Script* script = Script::cast(shared->script());
   rec->entry->set_script_id(script->id()->value());
   rec->size = code->ExecutableSize();

--- a/src/full-codegen.cc
+++ b/src/full-codegen.cc
@@ -860,6 +860,7 @@ void FullCodeGenerator::SetStatementPosition(int pos) {
 void FullCodeGenerator::SetSourcePosition(int pos) {
   if (pos != RelocInfo::kNoPosition) {
     masm_->positions_recorder()->RecordPosition(pos);
+    masm_->positions_recorder()->WriteRecordedPositions();
   }
 }
 

--- a/src/log.h
+++ b/src/log.h
@@ -142,6 +142,75 @@ class LowLevelLogger;
 class PerfJitLogger;
 class Sampler;
 
+// Mapping from the offset within generated code to source line number.
+class JITLineInfoTable : public Malloced {
+ public:
+   JITLineInfoTable() : pc_offset_infos_(20) {}
+
+   void SetPosition(unsigned int pc_offset, unsigned int src_line) {
+     AddPcOffsetInfo(PcOffsetInfo(pc_offset, src_line));
+    }
+
+   int GetSourceLineNumber(unsigned int pc_offset) const {
+     int length = pc_offset_infos_.length();
+     if (0 == length) return 0;
+
+     int low = 0;
+     int high = length - 1;
+
+     if (pc_offset > pc_offset_infos_[high].pc_offset_) {
+       return 0;  // out of range
+     }
+
+     while (low < high) {
+       int mid = (low + high) / 2;
+       const JITLineInfoTable::PcOffsetInfo& elem = pc_offset_infos_[mid];
+       if (elem.pc_offset_ > pc_offset) {
+         high = mid;
+         continue;
+       }
+       if (elem.pc_offset_ < pc_offset) {
+         low = mid + 1;
+         continue;
+       }
+       return elem.line_;  // found the element
+     }
+
+     int line = pc_offset_infos_[high].line_;
+     return line;
+   }
+
+   struct PcOffsetInfo {
+     PcOffsetInfo(unsigned int pc_offset, unsigned int src_line)
+        : pc_offset_(pc_offset), line_(src_line) { }
+
+       unsigned int pc_offset_;
+       unsigned int line_;
+   };
+
+   List<PcOffsetInfo>* entries() { return &pc_offset_infos_; }
+   const List<PcOffsetInfo>* entries() const { return &pc_offset_infos_; }
+
+   JITLineInfoTable& operator=(const JITLineInfoTable& other) {
+     if (this != &other) {
+       const List<PcOffsetInfo>* entries = other.entries();
+       if (entries) {
+         pc_offset_infos_.Clear();
+         pc_offset_infos_.AddAll(*entries);
+       }
+     }
+     return *this;
+   }
+
+ private:
+   void AddPcOffsetInfo(const PcOffsetInfo& pc_offset_info) {
+     pc_offset_infos_.Add(pc_offset_info);
+   }
+
+   // The data reported by code generator.
+   List<PcOffsetInfo> pc_offset_infos_;
+};
+
 class Logger {
  public:
 #define DECLARE_ENUM(enum_item, ignore) enum_item,

--- a/src/profile-generator-inl.h
+++ b/src/profile-generator-inl.h
@@ -15,7 +15,8 @@ CodeEntry::CodeEntry(Logger::LogEventsAndTags tag,
                      const char* name_prefix,
                      const char* resource_name,
                      int line_number,
-                     int column_number)
+                     int column_number,
+                     JITLineInfoTable* line_info)
     : tag_(tag),
       builtin_id_(Builtins::builtin_count),
       name_prefix_(name_prefix),
@@ -26,7 +27,11 @@ CodeEntry::CodeEntry(Logger::LogEventsAndTags tag,
       shared_id_(0),
       script_id_(v8::UnboundScript::kNoScriptId),
       no_frame_ranges_(NULL),
-      bailout_reason_(kEmptyBailoutReason) { }
+      bailout_reason_(kEmptyBailoutReason) {
+    if (NULL != line_info) {
+        line_info_ = *line_info;
+    }
+ }
 
 
 bool CodeEntry::is_js_function_tag(Logger::LogEventsAndTags tag) {
@@ -39,12 +44,18 @@ bool CodeEntry::is_js_function_tag(Logger::LogEventsAndTags tag) {
 }
 
 
+static bool LineTickMatch(void* a, void* b) {
+    return a == b;
+}
+
+
 ProfileNode::ProfileNode(ProfileTree* tree, CodeEntry* entry)
     : tree_(tree),
       entry_(entry),
       self_ticks_(0),
       children_(CodeEntriesMatch),
-      id_(tree->next_node_id()) { }
+      id_(tree->next_node_id()),
+      line_ticks_(LineTickMatch) { }
 
 } }  // namespace v8::internal
 

--- a/src/profile-generator.cc
+++ b/src/profile-generator.cc
@@ -207,6 +207,41 @@ ProfileNode* ProfileNode::FindOrAddChild(CodeEntry* entry) {
 }
 
 
+void ProfileNode::IncrementLineTicks(int src_line) {
+  if (src_line == v8::CpuProfileNode::kNoLineNumberInfo) return;
+  // Increment a hit counter of a certain source line.
+  // Add a new source line if not found.
+  HashMap::Entry* e =
+    line_ticks_.Lookup(reinterpret_cast<void*>(src_line), src_line, true);
+  if (NULL != e) {
+    e->value = static_cast<char*>(e->value) + 1;
+  }
+}
+
+
+bool ProfileNode::GetLineTicks(LineTick* entries,
+                               unsigned int number) const {
+  if (NULL == entries || number == 0) {
+    return false;
+  }
+
+  unsigned lineNumber = line_ticks_.occupancy();
+  if (lineNumber == 0) return false;
+  if (number < lineNumber) return false;
+
+  LineTick* entry = entries;
+
+  for (HashMap::Entry* p = line_ticks_.Start();
+       p != NULL;
+       p = line_ticks_.Next(p), entry++) {
+    entry->line = reinterpret_cast<intptr_t>(p->key);
+    entry->ticks = reinterpret_cast<intptr_t>(p->value);
+  }
+
+  return true;
+}
+
+
 void ProfileNode::Print(int indent) {
   OS::Print("%5u %*c %s%s %d #%d %s",
             self_ticks_,
@@ -252,7 +287,8 @@ ProfileTree::~ProfileTree() {
 }
 
 
-ProfileNode* ProfileTree::AddPathFromEnd(const Vector<CodeEntry*>& path) {
+ProfileNode* ProfileTree::AddPathFromEnd(const Vector<CodeEntry*>& path,
+                                         int src_line) {
   ProfileNode* node = root_;
   for (CodeEntry** entry = path.start() + path.length() - 1;
        entry != path.start() - 1;
@@ -262,11 +298,15 @@ ProfileNode* ProfileTree::AddPathFromEnd(const Vector<CodeEntry*>& path) {
     }
   }
   node->IncrementSelfTicks();
+  if (src_line != v8::CpuProfileNode::kNoLineNumberInfo) {
+    node->IncrementLineTicks(src_line);
+  }
   return node;
 }
 
 
-void ProfileTree::AddPathFromStart(const Vector<CodeEntry*>& path) {
+void ProfileTree::AddPathFromStart(const Vector<CodeEntry*>& path,
+                                   int src_line) {
   ProfileNode* node = root_;
   for (CodeEntry** entry = path.start();
        entry != path.start() + path.length();
@@ -276,6 +316,9 @@ void ProfileTree::AddPathFromStart(const Vector<CodeEntry*>& path) {
     }
   }
   node->IncrementSelfTicks();
+  if (src_line != v8::CpuProfileNode::kNoLineNumberInfo) {
+    node->IncrementLineTicks(src_line);
+  }
 }
 
 
@@ -336,8 +379,9 @@ CpuProfile::CpuProfile(const char* title, bool record_samples)
 }
 
 
-void CpuProfile::AddPath(TimeTicks timestamp, const Vector<CodeEntry*>& path) {
-  ProfileNode* top_frame_node = top_down_.AddPathFromEnd(path);
+void CpuProfile::AddPath(TimeTicks timestamp, const Vector<CodeEntry*>& path,
+                         int src_line) {
+  ProfileNode* top_frame_node = top_down_.AddPathFromEnd(path, src_line);
   if (record_samples_) {
     timestamps_.Add(timestamp);
     samples_.Add(top_frame_node);
@@ -525,13 +569,13 @@ void CpuProfilesCollection::RemoveProfile(CpuProfile* profile) {
 
 
 void CpuProfilesCollection::AddPathToCurrentProfiles(
-    TimeTicks timestamp, const Vector<CodeEntry*>& path) {
+    TimeTicks timestamp, const Vector<CodeEntry*>& path, int src_line) {
   // As starting / stopping profiles is rare relatively to this
   // method, we don't bother minimizing the duration of lock holding,
   // e.g. copying contents of the list to a local vector.
   current_profiles_semaphore_.Wait();
   for (int i = 0; i < current_profiles_.length(); ++i) {
-    current_profiles_[i]->AddPath(timestamp, path);
+    current_profiles_[i]->AddPath(timestamp, path, src_line);
   }
   current_profiles_semaphore_.Signal();
 }
@@ -543,13 +587,15 @@ CodeEntry* CpuProfilesCollection::NewCodeEntry(
       const char* name_prefix,
       const char* resource_name,
       int line_number,
-      int column_number) {
+      int column_number,
+      JITLineInfoTable* line_info) {
   CodeEntry* code_entry = new CodeEntry(tag,
                                         name,
                                         name_prefix,
                                         resource_name,
                                         line_number,
-                                        column_number);
+                                        column_number,
+                                        line_info);
   code_entries_.Add(code_entry);
   return code_entry;
 }
@@ -582,6 +628,15 @@ ProfileGenerator::ProfileGenerator(CpuProfilesCollection* profiles)
 }
 
 
+static int GetSourceLine(unsigned int pc_offset, CodeEntry* entry) {
+  int src_line = v8::CpuProfileNode::kNoLineNumberInfo;
+  const JITLineInfoTable& table = entry->line_info();
+  if (!table.entries()->length()) return src_line;
+  src_line = table.GetSourceLineNumber(pc_offset);
+  return src_line;
+}
+
+
 void ProfileGenerator::RecordTickSample(const TickSample& sample) {
   // Allocate space for stack frames + pc + function + vm-state.
   ScopedVector<CodeEntry*> entries(sample.frames_count + 3);
@@ -589,6 +644,7 @@ void ProfileGenerator::RecordTickSample(const TickSample& sample) {
   // entries vector with NULL values.
   CodeEntry** entry = entries.start();
   memset(entry, 0, entries.length() * sizeof(*entry));
+  int src_line = v8::CpuProfileNode::kNoLineNumberInfo;
   if (sample.pc != NULL) {
     if (sample.has_external_callback && sample.state == EXTERNAL &&
         sample.top_frame_type == StackFrame::EXIT) {
@@ -604,9 +660,11 @@ void ProfileGenerator::RecordTickSample(const TickSample& sample) {
       // ebp contains return address of the current function and skips caller's
       // frame. Check for this case and just skip such samples.
       if (pc_entry) {
+        Code* code = Code::cast(HeapObject::FromAddress(start));
         List<OffsetRange>* ranges = pc_entry->no_frame_ranges();
+        src_line = GetSourceLine(sample.pc - code->instruction_start(),
+                                 pc_entry);
         if (ranges) {
-          Code* code = Code::cast(HeapObject::FromAddress(start));
           int pc_offset = static_cast<int>(
               sample.pc - code->instruction_start());
           for (int i = 0; i < ranges->length(); i++) {
@@ -632,11 +690,25 @@ void ProfileGenerator::RecordTickSample(const TickSample& sample) {
       }
     }
 
+    bool unresolved_src = (src_line == v8::CpuProfileNode::kNoLineNumberInfo) ?
+                          true : false;
+
     for (const Address* stack_pos = sample.stack,
            *stack_end = stack_pos + sample.frames_count;
          stack_pos != stack_end;
          ++stack_pos) {
-      *entry++ = code_map_.FindEntry(*stack_pos);
+      Address start = NULL;
+      *entry = code_map_.FindEntry(*stack_pos, &start);
+      if (unresolved_src && NULL != *entry) {
+          Code* code = Code::cast(HeapObject::FromAddress(start));
+          src_line = GetSourceLine(*stack_pos - code->instruction_start(),
+                                   *entry);
+          if (src_line == v8::CpuProfileNode::kNoLineNumberInfo) {
+            src_line = (*entry)->line_number();
+          }
+          unresolved_src = false;
+      }
+      entry++;
     }
   }
 
@@ -654,7 +726,7 @@ void ProfileGenerator::RecordTickSample(const TickSample& sample) {
     }
   }
 
-  profiles_->AddPathToCurrentProfiles(sample.timestamp, entries);
+  profiles_->AddPathToCurrentProfiles(sample.timestamp, entries, src_line);
 }
 
 

--- a/test/cctest/test-cpu-profiler.cc
+++ b/test/cctest/test-cpu-profiler.cc
@@ -1006,6 +1006,157 @@ TEST(BoundFunctionCall) {
 }
 
 
+// Check that the profile tree for the script below will look like the
+// following:
+//
+// [Top down]:
+//  0  (root)0 #1
+//  15    start 20 #3 no reason
+//  3      foo 20 #4 TryCatchStatement
+//  121        bar 20 #5 TryCatchStatement
+//  223          loop 20 #6 no reason
+//
+// This tests checks distribution of the samples through the source lines.
+// The optimizing compiler is disabled for the hotest function to make
+// the test deterministic.
+
+static int GetHitLineSampleCount(const v8::CpuProfileNode* node) {
+  int sampleCount = 0;
+  unsigned int lineCount = node->GetHitLineCount();
+  if (lineCount) {
+    v8::LineTick* entries = new v8::LineTick[lineCount];
+    CHECK_EQ(true, node->GetLineTicks(entries, lineCount));
+    for (unsigned int i = 0; i < lineCount; i++) {
+      sampleCount += entries[i].ticks;
+    }
+    delete [] entries;
+  }
+  return sampleCount;
+}
+
+
+void CheckHitLine(unsigned int lineNo,
+                  const v8::CpuProfileNode* node,
+                  unsigned int sampleTotal,
+                  unsigned int threshold) {
+  bool found = false;
+
+  unsigned int lineCount = node->GetHitLineCount();
+  CHECK_GT(lineCount, 0);
+
+  v8::LineTick* entries = new v8::LineTick[lineCount];
+  CHECK_EQ(true, node->GetLineTicks(entries, lineCount));
+
+  unsigned int i = 0;
+  for (i = 0; i < lineCount; i++) {
+    if (entries[i].line == lineNo) {
+      found = true;
+      break;
+    }
+  }
+
+  CHECK_EQ(true, found);
+  CHECK_GT(entries[i].ticks * 100 / sampleTotal, threshold);
+
+  delete[] entries;
+}
+
+
+static void CheckBranchWithTickLines(LocalContext& env,
+                                     const v8::CpuProfile* profile) {
+  const v8::CpuProfileNode* root = profile->GetTopDownRoot();
+
+  const v8::CpuProfileNode* startNode =
+      GetChild(env->GetIsolate(), root, "start");
+  CHECK_EQ(1, startNode->GetChildrenCount());
+  CHECK_EQ(startNode->GetHitCount(), GetHitLineSampleCount(startNode));
+
+  const v8::CpuProfileNode* fooNode =
+      GetChild(env->GetIsolate(), startNode, "foo");
+  CHECK_EQ(1, fooNode->GetChildrenCount());
+  CHECK_EQ(fooNode->GetHitCount(), GetHitLineSampleCount(fooNode));
+
+  const v8::CpuProfileNode* barNode =
+      GetChild(env->GetIsolate(), fooNode, "bar");
+  CHECK_EQ(1, barNode->GetChildrenCount());
+  CHECK_EQ(barNode->GetHitCount(), GetHitLineSampleCount(barNode));
+  // Check that line #14 collects at least 90% of the samples.
+  CheckHitLine(14, barNode, barNode->GetHitCount(), 90);
+
+  const v8::CpuProfileNode* loopNode =
+     GetChild(env->GetIsolate(), barNode, "loop");
+  CHECK_EQ(0, loopNode->GetChildrenCount());
+  CHECK_EQ(loopNode->GetHitCount(), GetHitLineSampleCount(loopNode));
+
+  // Check that line #8 collects at least 80% of the samples
+  CheckHitLine(8, loopNode, loopNode->GetHitCount(), 80);
+}
+
+
+static const char* cpu_profiler_test_source3 = "function loop(timeout) {\n"
+"  with({}); // disable the optimizing compiler for this function"
+"  this.mmm = 0;\n"
+"  var start = Date.now();\n"
+"  while (Date.now() - start < timeout) {\n"
+"    var n = 100*1000;\n"
+"    while(n > 1) {\n"
+"      n--;\n"
+"      this.mmm += n * n * n;\n"
+"    }\n"
+"  }\n"
+"}\n"
+"function bar() {\n"
+"    try {\n"
+"       loop(10);\n"
+"    } catch(e) { }\n"
+"}\n"
+"function foo() {\n"
+"    try {\n"
+"       bar();\n"
+"    } catch (e) { }\n"
+"}\n"
+"function start(timeout) {\n"
+"  var start = Date.now();\n"
+"  do {\n"
+"    foo();\n"
+"    var duration = Date.now() - start;\n"
+"  } while (duration < timeout);\n"
+"  return duration;\n"
+"}\n";
+
+
+TEST(TickLines) {
+  LocalContext env;
+  v8::HandleScope scope(env->GetIsolate());
+  v8::Script::Compile(v8::String::NewFromUtf8(env->GetIsolate(),
+    cpu_profiler_test_source3))->Run();
+  v8::Local<v8::Function> function = v8::Local<v8::Function>::Cast(
+    env->Global()->Get(v8::String::NewFromUtf8(env->GetIsolate(), "start")));
+
+  int32_t profiling_interval_ms = 200;
+  v8::Handle<v8::Value> args[] = {
+      v8::Integer::New(env->GetIsolate(), profiling_interval_ms)
+  };
+
+  // The first run tests distribution of the samples through the source
+  // line information taken from "relocation info" created during code
+  // generation.
+  v8::CpuProfile* profile =
+      RunProfiler(env.local(), function, args, ARRAY_SIZE(args), 200);
+  function->Call(env->Global(), ARRAY_SIZE(args), args);
+  CheckBranchWithTickLines(env, profile);
+  profile->Delete();
+
+  // This is a case when the precompiled functions located on the heap
+  // are profiled. The second run tests that same source lines collect
+  // the expected number of samples.
+  profile = RunProfiler(env.local(), function, args, ARRAY_SIZE(args), 200);
+  function->Call(env->Global(), ARRAY_SIZE(args), args);
+  CheckBranchWithTickLines(env, profile);
+  profile->Delete();
+}
+
+
 static const char* call_function_test_source = "function bar(iterations) {\n"
 "}\n"
 "function start(duration) {\n"


### PR DESCRIPTION
The idea behind of this new solution is to use the existing "relocation info" instead of consumption the CodeLinePosition events emitted by the V8 compilers.
During generation code and relocation info are generated simultaneously. When code generation is done you each code object has associated "relocation info". Relocation information lets V8 mark interesting places in the generated code: pointers that might need to be relocated (after garbage collection), correspondences between the machine program counter and source locations for stack walking.
This patch:
1. Add more source positions info in reloc info to make it suitable for source level mapping. The amount of data should not increase dramatically because (1) V8 already marks  interesting places in the generated code and (2) V8 does not write redundant information (it writes a pair (pc_offset, pos) only if pos is changed and skip other)
2. When a sample happen, CPU profiler find a code object by pc, then use it reloc info to match the sample to a source line. If a source line is found that hit counter for this line is increased by one.
3. Add a new public V8 API to get the hit source lines by CDT CPU profiler. It's expected a minor patch in Blink to pack the source level info in JSON.
4. Add a test to check how the samples are distributed through source lines. 
