### PR TITLE
V8 CPU profiler: source level support

### DIFF
--- a/include/v8-profiler.h
+++ b/include/v8-profiler.h
@@ -17,6 +17,14 @@ struct HeapStatsUpdate;
 
 typedef uint32_t SnapshotObjectId;
 
+typedef struct {
+  /** The 1-based number of the source line where the function originates. */
+  unsigned int line;
+
+  /** The count of samples associated with the source line. */
+  unsigned int ticks;
+} LineTick;
+
 /**
  * CpuProfileNode represents a node in a call graph.
  */
@@ -42,6 +50,17 @@ class V8_EXPORT CpuProfileNode {
    * kNoColumnNumberInfo if no column number information is available.
    */
   int GetColumnNumber() const;
+
+  /**
+   * Returns the number of the function's source lines that collect the samples.
+   */
+  unsigned int GetHitLineCount() const;
+
+  /** Returns the set of source lines that collect the samples.
+   *  The caller allocates buffer and responsible for releasing it.
+   *  True if all available entries are copied, otherwise false.
+   */
+  bool GetLineTicks(LineTick* entries, unsigned int number) const;
 
   /** Returns bailout reason for the function
     * if the optimization was disabled for it.

--- a/src/api.cc
+++ b/src/api.cc
@@ -7001,6 +7001,19 @@ int CpuProfileNode::GetColumnNumber() const {
 }
 
 
+unsigned int CpuProfileNode::GetHitLineCount() const {
+  const i::ProfileNode* node = reinterpret_cast<const i::ProfileNode*>(this);
+  return node->GetHitLineCount();
+}
+
+
+bool CpuProfileNode::GetLineTicks(LineTick* entries,
+                                  unsigned int number) const {
+  const i::ProfileNode* node = reinterpret_cast<const i::ProfileNode*>(this);
+  return node->GetLineTicks(entries, number);
+}
+
+
 const char* CpuProfileNode::GetBailoutReason() const {
   const i::ProfileNode* node = reinterpret_cast<const i::ProfileNode*>(this);
   return node->entry()->bailout_reason();

--- a/src/full-codegen.cc
+++ b/src/full-codegen.cc
@@ -863,6 +863,7 @@ void FullCodeGenerator::SetStatementPosition(int pos) {
 void FullCodeGenerator::SetSourcePosition(int pos) {
   if (pos != RelocInfo::kNoPosition) {
     masm_->positions_recorder()->RecordPosition(pos);
+    masm_->positions_recorder()->WriteRecordedPositions();
   }
 }
 

--- a/src/profile-generator-inl.h
+++ b/src/profile-generator-inl.h
@@ -15,7 +15,8 @@ CodeEntry::CodeEntry(Logger::LogEventsAndTags tag,
                      const char* name_prefix,
                      const char* resource_name,
                      int line_number,
-                     int column_number)
+                     int column_number,
+                     JITLineInfoTable* line_info)
     : tag_(tag),
       builtin_id_(Builtins::builtin_count),
       name_prefix_(name_prefix),
@@ -26,7 +27,11 @@ CodeEntry::CodeEntry(Logger::LogEventsAndTags tag,
       shared_id_(0),
       script_id_(v8::UnboundScript::kNoScriptId),
       no_frame_ranges_(NULL),
-      bailout_reason_(kEmptyBailoutReason) { }
+      bailout_reason_(kEmptyBailoutReason) {
+    if (NULL != line_info) {
+      line_info_ = *line_info;
+    }
+}
 
 
 bool CodeEntry::is_js_function_tag(Logger::LogEventsAndTags tag) {
@@ -39,12 +44,18 @@ bool CodeEntry::is_js_function_tag(Logger::LogEventsAndTags tag) {
 }
 
 
+static bool LineTickMatch(void* a, void* b) {
+    return a == b;
+}
+
+
 ProfileNode::ProfileNode(ProfileTree* tree, CodeEntry* entry)
     : tree_(tree),
       entry_(entry),
       self_ticks_(0),
       children_(CodeEntriesMatch),
-      id_(tree->next_node_id()) { }
+      id_(tree->next_node_id()),
+      line_ticks_(LineTickMatch) { }
 
 } }  // namespace v8::internal
 


### PR DESCRIPTION
This patch had been already reviewed last time. I did not modify it.

The idea behind of this new solution is to use the existing "relocation info" instead of consumption the CodeLinePosition events emitted by the V8 compilers.
During generation code and relocation info are generated simultaneously. When code generation is done you each code object has associated "relocation info". Relocation information lets V8 to mark interesting places in the generated code: the pointers that might need to be relocated (after garbage collection), correspondences between the machine program counter and source locations for stack walking.
This patch:
1. Add more source positions info in reloc info to make it suitable for source level mapping. The amount of data should not be increased dramatically because (1) V8 already marks interesting places in the generated code and (2) V8 does not write redundant information (it writes a pair (pc_offset, pos) only if pos is changed and skips other)
2. When a sample happens, CPU profiler finds a code object by pc, then use its reloc info to match the sample to a source line. If a source line is found that hit counter is increased by one for this line 
3. Add a new public V8 API to get the hit source lines by CDT CPU profiler. It's expected a minor patch in Blink to pack the source level info in JSON.
4. Add a test that checks how the samples are distributed through source lines. It tests two cases: (1) relocation info created during code generation and (2) relocation info associated with precompiled function's version.
