### PR TITLE
[PATCH] fixed compilation v8 on mips

### DIFF
--- a/src/arm/deoptimizer-arm.cc
+++ b/src/arm/deoptimizer-arm.cc
@@ -111,6 +111,10 @@ void Deoptimizer::SetPlatformCompiledStubRegisters(
 }
 
 
+void Deoptimizer::CopyDoubleRegisters(FrameDescription* output_frame) {
+}
+
+
 void Deoptimizer::CopySIMD128Registers(FrameDescription* output_frame) {
   for (int i = 0; i < DwVfpRegister::kMaxNumRegisters; ++i) {
     double double_value = input_->GetDoubleRegister(i);
@@ -350,13 +354,13 @@ void FrameDescription::SetCallerConstantPool(unsigned offset, intptr_t value) {
 
 
 double FrameDescription::GetDoubleRegister(unsigned n) const {
-  DCHECK(n < 2 * arraysize(simd128_registers_));
+  DCHECK(n < 2 * simd128_registers_.size());
   return simd128_registers_[n / 2].d[n % 2];
 }
 
 
 void FrameDescription::SetDoubleRegister(unsigned n, double value) {
-  DCHECK(n < 2 * arraysize(simd128_registers_));
+  DCHECK(n < 2 * simd128_registers_.size());
   simd128_registers_[n / 2].d[n % 2] = value;
 }
 

--- a/src/deoptimizer.cc
+++ b/src/deoptimizer.cc
@@ -1772,6 +1772,9 @@ void Deoptimizer::DoComputeCompiledStubFrame(TranslationIterator* iterator,
   }
 
   // Copy the double registers from the input into the output frame.
+  CopyDoubleRegisters(output_frame);
+
+  // Copy the simd128 registers from the input into the output frame.
   CopySIMD128Registers(output_frame);
 
   // Fill registers containing handler and number of parameters.

--- a/src/ia32/deoptimizer-ia32.cc
+++ b/src/ia32/deoptimizer-ia32.cc
@@ -204,6 +204,10 @@ void Deoptimizer::SetPlatformCompiledStubRegisters(
 }
 
 
+void Deoptimizer::CopyDoubleRegisters(FrameDescription* output_frame) {
+}
+
+
 void Deoptimizer::CopySIMD128Registers(FrameDescription* output_frame) {
   for (int i = 0; i < XMMRegister::kMaxNumAllocatableRegisters; ++i) {
     simd128_value_t xmm_value = input_->GetSIMD128Register(i);
@@ -426,13 +430,13 @@ void FrameDescription::SetCallerConstantPool(unsigned offset, intptr_t value) {
 
 
 double FrameDescription::GetDoubleRegister(unsigned n) const {
-  DCHECK(n < arraysize(simd128_registers_));
+  DCHECK(n < simd128_registers_.size());
   return simd128_registers_[n].d[0];
 }
 
 
 void FrameDescription::SetDoubleRegister(unsigned n, double value) {
-  DCHECK(n < arraysize(simd128_registers_));
+  DCHECK(n < simd128_registers_.size());
   simd128_registers_[n].d[0] = value;
 }
 

--- a/src/mips/assembler-mips-inl.h
+++ b/src/mips/assembler-mips-inl.h
@@ -48,6 +48,7 @@ namespace internal {
 
 
 bool CpuFeatures::SupportsCrankshaft() { return IsSupported(FPU); }
+bool CpuFeatures::SupportsSIMD128InCrankshaft() { return false; }
 
 
 // -----------------------------------------------------------------------------

--- a/src/mips/assembler-mips.h
+++ b/src/mips/assembler-mips.h
@@ -355,6 +355,19 @@ struct FPUControlRegister {
 const FPUControlRegister no_fpucreg = { kInvalidFPUControlRegister };
 const FPUControlRegister FCSR = { kFCSRRegister };
 
+struct SIMD128Register {
+  static const int kMaxNumRegisters = 0;
+
+  static int ToAllocationIndex(SIMD128Register reg) {
+    UNIMPLEMENTED();
+    return -1;
+  }
+
+  static const char* AllocationIndexToString(int index) {
+    UNIMPLEMENTED();
+    return NULL;
+  }
+};
 
 // -----------------------------------------------------------------------------
 // Machine instruction Operands.

--- a/src/mips/deoptimizer-mips.cc
+++ b/src/mips/deoptimizer-mips.cc
@@ -116,6 +116,10 @@ void Deoptimizer::CopyDoubleRegisters(FrameDescription* output_frame) {
 }
 
 
+void Deoptimizer::CopySIMD128Registers(FrameDescription* output_frame) {
+}
+
+
 bool Deoptimizer::HasAlignmentPadding(JSFunction* function) {
   // There is no dynamic alignment padding on MIPS in the input frame.
   return false;
@@ -393,6 +397,18 @@ void FrameDescription::SetCallerFp(unsigned offset, intptr_t value) {
 void FrameDescription::SetCallerConstantPool(unsigned offset, intptr_t value) {
   // No out-of-line constant pool support.
   UNREACHABLE();
+}
+
+
+double FrameDescription::GetDoubleRegister(unsigned n) const {
+  DCHECK(n < double_registers_.size());
+  return double_registers_[n];
+}
+
+
+void FrameDescription::SetDoubleRegister(unsigned n, double value) {
+  DCHECK(n < double_registers_.size());
+  double_registers_[n] = value;
 }
 
 

--- a/src/mips/lithium-codegen-mips.cc
+++ b/src/mips/lithium-codegen-mips.cc
@@ -3189,10 +3189,16 @@ void LCodeGen::DoLoadKeyedExternalArray(LLoadKeyed* instr) {
           DeoptimizeIf(Ugreater_equal, instr, result, Operand(0x80000000));
         }
         break;
+      case INT32x4_ELEMENTS:
       case FLOAT32_ELEMENTS:
+      case FLOAT32x4_ELEMENTS:
       case FLOAT64_ELEMENTS:
+      case FLOAT64x2_ELEMENTS:
+      case EXTERNAL_INT32x4_ELEMENTS:
       case EXTERNAL_FLOAT32_ELEMENTS:
+      case EXTERNAL_FLOAT32x4_ELEMENTS:
       case EXTERNAL_FLOAT64_ELEMENTS:
+      case EXTERNAL_FLOAT64x2_ELEMENTS:
       case FAST_DOUBLE_ELEMENTS:
       case FAST_ELEMENTS:
       case FAST_SMI_ELEMENTS:
@@ -4280,10 +4286,16 @@ void LCodeGen::DoStoreKeyedExternalArray(LStoreKeyed* instr) {
       case UINT32_ELEMENTS:
         __ sw(value, mem_operand);
         break;
+      case INT32x4_ELEMENTS:
       case FLOAT32_ELEMENTS:
+      case FLOAT32x4_ELEMENTS:
       case FLOAT64_ELEMENTS:
+      case FLOAT64x2_ELEMENTS:
+      case EXTERNAL_INT32x4_ELEMENTS:
       case EXTERNAL_FLOAT32_ELEMENTS:
+      case EXTERNAL_FLOAT32x4_ELEMENTS:
       case EXTERNAL_FLOAT64_ELEMENTS:
+      case EXTERNAL_FLOAT64x2_ELEMENTS:
       case FAST_DOUBLE_ELEMENTS:
       case FAST_ELEMENTS:
       case FAST_SMI_ELEMENTS:

--- a/src/mips/lithium-mips.cc
+++ b/src/mips/lithium-mips.cc
@@ -1226,6 +1226,41 @@ LInstruction* LChunkBuilder::DoMathRound(HUnaryMathOperation* instr) {
 }
 
 
+LInstruction* LChunkBuilder::DoNullarySIMDOperation(
+    HNullarySIMDOperation* instr) {
+  UNIMPLEMENTED();
+  return NULL;
+}
+
+
+LInstruction* LChunkBuilder::DoUnarySIMDOperation(
+    HUnarySIMDOperation* instr) {
+  UNIMPLEMENTED();
+  return NULL;
+}
+
+
+LInstruction* LChunkBuilder::DoBinarySIMDOperation(
+    HBinarySIMDOperation* instr) {
+  UNIMPLEMENTED();
+  return NULL;
+}
+
+
+LInstruction* LChunkBuilder::DoTernarySIMDOperation(
+    HTernarySIMDOperation* instr) {
+  UNIMPLEMENTED();
+  return NULL;
+}
+
+
+LInstruction* LChunkBuilder::DoQuarternarySIMDOperation(
+    HQuarternarySIMDOperation* instr) {
+  UNIMPLEMENTED();
+  return NULL;
+}
+
+
 LInstruction* LChunkBuilder::DoCallNew(HCallNew* instr) {
   LOperand* context = UseFixed(instr->context(), cp);
   LOperand* constructor = UseFixed(instr->constructor(), a1);

--- a/src/x64/deoptimizer-x64.cc
+++ b/src/x64/deoptimizer-x64.cc
@@ -113,6 +113,10 @@ void Deoptimizer::SetPlatformCompiledStubRegisters(
 }
 
 
+void Deoptimizer::CopyDoubleRegisters(FrameDescription* output_frame) {
+}
+
+
 void Deoptimizer::CopySIMD128Registers(FrameDescription* output_frame) {
   for (int i = 0; i < XMMRegister::NumAllocatableRegisters(); ++i) {
     simd128_value_t xmm_value = input_->GetSIMD128Register(i);
@@ -348,13 +352,13 @@ void FrameDescription::SetCallerConstantPool(unsigned offset, intptr_t value) {
 
 
 double FrameDescription::GetDoubleRegister(unsigned n) const {
-  DCHECK(n < arraysize(simd128_registers_));
+  DCHECK(n < simd128_registers_.size());
   return simd128_registers_[n].d[0];
 }
 
 
 void FrameDescription::SetDoubleRegister(unsigned n, double value) {
-  DCHECK(n < arraysize(simd128_registers_));
+  DCHECK(n < simd128_registers_.size());
   simd128_registers_[n].d[0] = value;
 }
 


### PR DESCRIPTION
Issue appears in https://github.com/crosswalk-project/v8-crosswalk/commit/e9da1c91fe411d3ae67a51c0433f3bf672572475
which does not update mips architecture.

Fixed by bringing back double_registers_ needed in deoptimizer-mips.cc

Signed-off-by: Vasyl Vavrychuk vasyl.vavrychuk@globallogic.com
