### PR TITLE
Fix invalid native context reference in simd128-tag

### DIFF
--- a/src/ia32/macro-assembler-ia32.cc
+++ b/src/ia32/macro-assembler-ia32.cc
@@ -1695,27 +1695,36 @@ void MacroAssembler::AllocateHeapNumber(Register result,
 
 
 #define SIMD128_HEAP_ALLOCATE_FUNCTIONS(V) \
-  V(Float32x4, float32x4)                  \
-  V(Float64x2, float64x2)                  \
-  V(Int32x4, int32x4)
+  V(Float32x4, float32x4, FLOAT32x4)       \
+  V(Float64x2, float64x2, FLOAT64x2)       \
+  V(Int32x4, int32x4, INT32x4)
 
-#define DECLARE_SIMD_HEAP_ALLOCATE_FUNCTION(TYPE, type)                    \
-void MacroAssembler::Allocate##TYPE(Register result,                       \
+#define DECLARE_SIMD_HEAP_ALLOCATE_FUNCTION(Type, type, TYPE)              \
+void MacroAssembler::Allocate##Type(Register result,                       \
                                     Register scratch1,                     \
                                     Register scratch2,                     \
                                     Label* gc_required) {                  \
   /* Allocate SIMD128 object */                                            \
-  Allocate(TYPE::kSize, result, scratch1, no_reg, gc_required, TAG_OBJECT);\
-                                                                           \
-  mov(FieldOperand(result, JSObject::kMapOffset),                          \
-      Immediate(reinterpret_cast<intptr_t>(                                \
-          isolate()->native_context()->type##_function()->initial_map())));\
+  Allocate(Type::kSize, result, scratch1, no_reg, gc_required, TAG_OBJECT);\
+  /* Load the initial map and assign to new allocated object. */           \
+  mov(scratch1, Operand(ebp, StandardFrameConstants::kContextOffset));     \
+  mov(scratch1,                                                            \
+      Operand(scratch1,                                                    \
+              Context::SlotOffset(Context::GLOBAL_OBJECT_INDEX)));         \
+  mov(scratch1,                                                            \
+      FieldOperand(scratch1, GlobalObject::kNativeContextOffset));         \
+  mov(scratch1,                                                            \
+      Operand(scratch1,                                                    \
+              Context::SlotOffset(Context::TYPE##_FUNCTION_INDEX)));       \
+  LoadGlobalFunctionInitialMap(scratch1, scratch1);                        \
+  mov(FieldOperand(result, JSObject::kMapOffset), scratch1);               \
+  /* Initialize properties and elements. */                                \
   mov(FieldOperand(result, JSObject::kPropertiesOffset),                   \
       Immediate(isolate()->factory()->empty_fixed_array()));               \
   mov(FieldOperand(result, JSObject::kElementsOffset),                     \
       Immediate(isolate()->factory()->empty_fixed_array()));               \
   /* Allocate FixedTypedArray object */                                    \
-  Allocate(FixedTypedArrayBase::kDataOffset + k##TYPE##Size,               \
+  Allocate(FixedTypedArrayBase::kDataOffset + k##Type##Size,               \
            scratch1, scratch2, no_reg, gc_required, TAG_OBJECT);           \
                                                                            \
   mov(FieldOperand(scratch1, FixedTypedArrayBase::kMapOffset),             \
@@ -1725,7 +1734,7 @@ void MacroAssembler::Allocate##TYPE(Register result,                       \
   mov(FieldOperand(scratch1, FixedTypedArrayBase::kLengthOffset),          \
       scratch2);                                                           \
   /* Assign TifxedTypedArray object to SIMD128 object */                   \
-  mov(FieldOperand(result, TYPE::kValueOffset), scratch1);                 \
+  mov(FieldOperand(result, Type::kValueOffset), scratch1);                 \
 }
 
 SIMD128_HEAP_ALLOCATE_FUNCTIONS(DECLARE_SIMD_HEAP_ALLOCATE_FUNCTION)

--- a/src/ia32/macro-assembler-ia32.h
+++ b/src/ia32/macro-assembler-ia32.h
@@ -645,19 +645,19 @@ class MacroAssembler: public Assembler {
   // Returns tagged pointer in result register, or jumps to gc_required if new
   // space is full.
   void AllocateFloat32x4(Register result,
-                          Register scratch1,
-                          Register scratch2,
-                          Label* gc_required);
-
-  void AllocateInt32x4(Register result,
-                       Register scratch1,
-                       Register scratch2,
-                       Label* gc_required);
+                         Register scratch1,
+                         Register scratch2,
+                         Label* gc_required);
 
   void AllocateFloat64x2(Register result,
                          Register scratch1,
                          Register scratch2,
                          Label* gc_required);
+
+  void AllocateInt32x4(Register result,
+                       Register scratch1,
+                       Register scratch2,
+                       Label* gc_required);
 
   // Allocate a sequential string. All the header fields of the string object
   // are initialized.

--- a/src/x64/macro-assembler-x64.cc
+++ b/src/x64/macro-assembler-x64.cc
@@ -4679,23 +4679,32 @@ void MacroAssembler::AllocateHeapNumber(Register result,
 
 
 #define SIMD128_HEAP_ALLOCATE_FUNCTIONS(V) \
-  V(Float32x4, float32x4)                  \
-  V(Float64x2, float64x2)                  \
-  V(Int32x4, int32x4)
+  V(Float32x4, float32x4, FLOAT32x4)       \
+  V(Float64x2, float64x2, FLOAT64x2)       \
+  V(Int32x4, int32x4, INT32x4)
 
-#define DECLARE_SIMD_HEAP_ALLOCATE_FUNCTION(TYPE, type)                    \
-void MacroAssembler::Allocate##TYPE(Register result,                       \
+#define DECLARE_SIMD_HEAP_ALLOCATE_FUNCTION(Type, type, TYPE)              \
+void MacroAssembler::Allocate##Type(Register result,                       \
                                     Register scratch1,                     \
                                     Register scratch2,                     \
                                     Register scratch3,                     \
                                     Label* gc_required) {                  \
   /* Allocate SIMD128 object. */                                           \
-  Allocate(TYPE::kSize, result, scratch1, no_reg, gc_required, TAG_OBJECT);\
-  Handle<Map> simd128_map(                                                 \
-      isolate()->native_context()->type##_function()->initial_map());      \
-  MoveHeapObject(kScratchRegister, simd128_map);                           \
+  Allocate(Type::kSize, result, scratch1, no_reg, gc_required, TAG_OBJECT);\
+  /* Load the initial map and assign to new allocated object. */           \
+  movp(scratch1, Operand(rbp, StandardFrameConstants::kContextOffset));    \
+  movp(scratch1,                                                           \
+       Operand(scratch1,                                                   \
+               Context::SlotOffset(Context::GLOBAL_OBJECT_INDEX)));        \
+  movp(scratch1,                                                           \
+       FieldOperand(scratch1, GlobalObject::kNativeContextOffset));        \
+  movp(scratch1,                                                           \
+       Operand(scratch1,                                                   \
+               Context::SlotOffset(Context::TYPE##_FUNCTION_INDEX)));      \
+  LoadGlobalFunctionInitialMap(scratch1, scratch1);                        \
   movp(FieldOperand(result, JSObject::kMapOffset),                         \
-       kScratchRegister);                                                  \
+       scratch1);                                                          \
+  /* Initialize the properties and elements. */                            \
   MoveHeapObject(kScratchRegister,                                         \
                  isolate()->factory()->empty_fixed_array());               \
   movp(FieldOperand(result, JSObject::kPropertiesOffset),                  \
@@ -4703,7 +4712,7 @@ void MacroAssembler::Allocate##TYPE(Register result,                       \
   movp(FieldOperand(result, JSObject::kElementsOffset),                    \
        kScratchRegister);                                                  \
   /* Allocate FixedTypedArray object. */                                   \
-  Allocate(FixedTypedArrayBase::kDataOffset + k##TYPE##Size,               \
+  Allocate(FixedTypedArrayBase::kDataOffset + k##Type##Size,               \
            scratch1, scratch2, no_reg, gc_required, TAG_OBJECT);           \
   MoveHeapObject(kScratchRegister,                                         \
                  isolate()->factory()->fixed_##type##_array_map());        \
@@ -4714,7 +4723,7 @@ void MacroAssembler::Allocate##TYPE(Register result,                       \
   movp(FieldOperand(scratch1, FixedTypedArrayBase::kLengthOffset),         \
        scratch2);                                                          \
   /* Assign FixedTypedArray object to SIMD128 object. */                   \
-  movp(FieldOperand(result, TYPE::kValueOffset), scratch1);                \
+  movp(FieldOperand(result, Type::kValueOffset), scratch1);                \
 }
 
 SIMD128_HEAP_ALLOCATE_FUNCTIONS(DECLARE_SIMD_HEAP_ALLOCATE_FUNCTION)

--- a/src/x64/macro-assembler-x64.h
+++ b/src/x64/macro-assembler-x64.h
@@ -1203,22 +1203,22 @@ class MacroAssembler: public Assembler {
   // Returns tagged pointer in result register, or jumps to gc_required if new
   // space is full.
   void AllocateFloat32x4(Register result,
-                          Register scratch1,
-                          Register scratch2,
-                          Register scratch3,
-                          Label* gc_required);
-
-  void AllocateInt32x4(Register result,
-                       Register scratch1,
-                       Register scratch2,
-                       Register scratch3,
-                       Label* gc_required);
+                         Register scratch1,
+                         Register scratch2,
+                         Register scratch3,
+                         Label* gc_required);
 
   void AllocateFloat64x2(Register result,
                          Register scratch1,
                          Register scratch2,
                          Register scratch3,
                          Label* gc_required);
+
+  void AllocateInt32x4(Register result,
+                       Register scratch1,
+                       Register scratch2,
+                       Register scratch3,
+                       Label* gc_required);
 
   // Allocate a sequential string. All the header fields of the string object
   // are initialized.


### PR DESCRIPTION
The solution is to inline the native context load.

BUG=XWALK-2255
(cherry picked from commit 5aa07fb60139abfc847c4398c1b9c252711b2ce0)
