### PR TITLE
[SIMD.js] Refactor the simd128 registers in deoptimizer

### DIFF
--- a/src/arm/deoptimizer-arm.cc
+++ b/src/arm/deoptimizer-arm.cc
@@ -354,14 +354,36 @@ void FrameDescription::SetCallerConstantPool(unsigned offset, intptr_t value) {
 
 
 double FrameDescription::GetDoubleRegister(unsigned n) const {
-  DCHECK(n < 2 * simd128_registers_.size());
+  DCHECK(n < 2 * arraysize(simd128_registers_));
   return simd128_registers_[n / 2].d[n % 2];
 }
 
 
 void FrameDescription::SetDoubleRegister(unsigned n, double value) {
-  DCHECK(n < 2 * simd128_registers_.size());
+  DCHECK(n < 2 * arraysize(simd128_registers_));
   simd128_registers_[n / 2].d[n % 2] = value;
+}
+
+
+simd128_value_t FrameDescription::GetSIMD128Register(unsigned n) const {
+  DCHECK(n < arraysize(simd128_registers_));
+  return simd128_registers_[n];
+}
+
+
+void FrameDescription::SetSIMD128Register(unsigned n, simd128_value_t value) {
+  DCHECK(n < arraysize(simd128_registers_));
+  simd128_registers_[n] = value;
+}
+
+
+int FrameDescription::double_registers_offset() {
+  return OFFSET_OF(FrameDescription, simd128_registers_);
+}
+
+
+int FrameDescription::simd128_registers_offset() {
+  return OFFSET_OF(FrameDescription, simd128_registers_);
 }
 
 

--- a/src/arm64/deoptimizer-arm64.cc
+++ b/src/arm64/deoptimizer-arm64.cc
@@ -355,14 +355,37 @@ void FrameDescription::SetCallerConstantPool(unsigned offset, intptr_t value) {
 
 
 double FrameDescription::GetDoubleRegister(unsigned n) const {
-  DCHECK(n < double_registers_.size());
+  DCHECK(n < arraysize(double_registers_));
   return double_registers_[n];
 }
 
 
 void FrameDescription::SetDoubleRegister(unsigned n, double value) {
-  DCHECK(n < double_registers_.size());
+  DCHECK(n < arraysize(double_registers_));
   double_registers_[n] = value;
+}
+
+
+simd128_value_t FrameDescription::GetSIMD128Register(unsigned n) const {
+  UNREACHABLE();
+  simd128_value_t value;
+  return value;
+}
+
+
+void FrameDescription::SetSIMD128Register(unsigned n, simd128_value_t value) {
+  UNREACHABLE();
+}
+
+
+int FrameDescription::double_registers_offset() {
+  return OFFSET_OF(FrameDescription, double_registers_);
+}
+
+
+int FrameDescription::simd128_registers_offset() {
+  UNREACHABLE();
+  return -1;
 }
 
 

--- a/src/ia32/deoptimizer-ia32.cc
+++ b/src/ia32/deoptimizer-ia32.cc
@@ -430,14 +430,36 @@ void FrameDescription::SetCallerConstantPool(unsigned offset, intptr_t value) {
 
 
 double FrameDescription::GetDoubleRegister(unsigned n) const {
-  DCHECK(n < simd128_registers_.size());
+  DCHECK(n < arraysize(simd128_registers_));
   return simd128_registers_[n].d[0];
 }
 
 
 void FrameDescription::SetDoubleRegister(unsigned n, double value) {
-  DCHECK(n < simd128_registers_.size());
+  DCHECK(n < arraysize(simd128_registers_));
   simd128_registers_[n].d[0] = value;
+}
+
+
+simd128_value_t FrameDescription::GetSIMD128Register(unsigned n) const {
+  DCHECK(n < arraysize(simd128_registers_));
+  return simd128_registers_[n];
+}
+
+
+void FrameDescription::SetSIMD128Register(unsigned n, simd128_value_t value) {
+  DCHECK(n < arraysize(simd128_registers_));
+  simd128_registers_[n] = value;
+}
+
+
+int FrameDescription::double_registers_offset() {
+  return OFFSET_OF(FrameDescription, simd128_registers_);
+}
+
+
+int FrameDescription::simd128_registers_offset() {
+  return OFFSET_OF(FrameDescription, simd128_registers_);
 }
 
 

--- a/src/mips/assembler-mips.h
+++ b/src/mips/assembler-mips.h
@@ -355,20 +355,6 @@ struct FPUControlRegister {
 const FPUControlRegister no_fpucreg = { kInvalidFPUControlRegister };
 const FPUControlRegister FCSR = { kFCSRRegister };
 
-struct SIMD128Register {
-  static const int kMaxNumRegisters = 0;
-
-  static int ToAllocationIndex(SIMD128Register reg) {
-    UNIMPLEMENTED();
-    return -1;
-  }
-
-  static const char* AllocationIndexToString(int index) {
-    UNIMPLEMENTED();
-    return NULL;
-  }
-};
-
 // -----------------------------------------------------------------------------
 // Machine instruction Operands.
 

--- a/src/mips/deoptimizer-mips.cc
+++ b/src/mips/deoptimizer-mips.cc
@@ -401,14 +401,37 @@ void FrameDescription::SetCallerConstantPool(unsigned offset, intptr_t value) {
 
 
 double FrameDescription::GetDoubleRegister(unsigned n) const {
-  DCHECK(n < double_registers_.size());
+  DCHECK(n < arraysize(double_registers_));
   return double_registers_[n];
 }
 
 
 void FrameDescription::SetDoubleRegister(unsigned n, double value) {
-  DCHECK(n < double_registers_.size());
+  DCHECK(n < arraysize(double_registers_));
   double_registers_[n] = value;
+}
+
+
+simd128_value_t FrameDescription::GetSIMD128Register(unsigned n) const {
+  UNREACHABLE();
+  simd128_value_t value;
+  return value;
+}
+
+
+void FrameDescription::SetSIMD128Register(unsigned n, simd128_value_t value) {
+  UNREACHABLE();
+}
+
+
+int FrameDescription::double_registers_offset() {
+  return OFFSET_OF(FrameDescription, double_registers_);
+}
+
+
+int FrameDescription::simd128_registers_offset() {
+  UNREACHABLE();
+  return -1;
 }
 
 

--- a/src/x64/deoptimizer-x64.cc
+++ b/src/x64/deoptimizer-x64.cc
@@ -352,14 +352,36 @@ void FrameDescription::SetCallerConstantPool(unsigned offset, intptr_t value) {
 
 
 double FrameDescription::GetDoubleRegister(unsigned n) const {
-  DCHECK(n < simd128_registers_.size());
+  DCHECK(n < arraysize(simd128_registers_));
   return simd128_registers_[n].d[0];
 }
 
 
 void FrameDescription::SetDoubleRegister(unsigned n, double value) {
-  DCHECK(n < simd128_registers_.size());
+  DCHECK(n < arraysize(simd128_registers_));
   simd128_registers_[n].d[0] = value;
+}
+
+
+simd128_value_t FrameDescription::GetSIMD128Register(unsigned n) const {
+  DCHECK(n < arraysize(simd128_registers_));
+  return simd128_registers_[n];
+}
+
+
+void FrameDescription::SetSIMD128Register(unsigned n, simd128_value_t value) {
+  DCHECK(n < arraysize(simd128_registers_));
+  simd128_registers_[n] = value;
+}
+
+
+int FrameDescription::double_registers_offset() {
+  return OFFSET_OF(FrameDescription, simd128_registers_);
+}
+
+
+int FrameDescription::simd128_registers_offset() {
+  return OFFSET_OF(FrameDescription, simd128_registers_);
 }
 
 


### PR DESCRIPTION
Only replace double registers with simd128 registers on architectures that
support this. Currently they are ia32, x64 and arm.
