### PR TITLE
fixed 2 bugs in XDK HeapProfiler: object's types determination and compilation on Windows

### DIFF
--- a/src/xdk-utils.h
+++ b/src/xdk-utils.h
@@ -17,20 +17,50 @@ namespace internal {
 class AggregatedChunks;
 class StringsStorage;
 class JavaScriptFrame;
+class RuntimeInfo;
 
 // --- ClassNames
 class ClassNames {
  public:
-  explicit ClassNames(StringsStorage* names);
+  explicit ClassNames(StringsStorage* names, Heap* heap);
 
   unsigned registerName(const char* className);
   std::string SerializeChunk();
-  String* GetConstructorName(Address address);
+  bool IsEssentialObject(Object* object);
+  void registerNameForDependent(HeapObject* object,
+                                RuntimeInfo* runtime_info,
+                                unsigned id);
+  unsigned GetConstructorName(Address address, RuntimeInfo* runtime_info);
+
 
  private:
   unsigned counter_;
   HashMap char_to_idx_;
   StringsStorage* names_;
+  Heap* heap_;
+
+  unsigned id_native_bind_;
+  unsigned id_conc_string_;
+  unsigned id_sliced_string_;
+  unsigned id_string_;
+  unsigned id_symbol_;
+  unsigned id_code_;
+  unsigned id_system_ncontext_;
+  unsigned id_system_context_;
+  unsigned id_array_;
+  unsigned id_number_;
+  unsigned id_system_;
+  unsigned id_shared_fi_;
+  unsigned id_script_;
+  unsigned id_regexp_;
+  unsigned id_function_bindings_;
+  unsigned id_function_literals_;
+  unsigned id_objects_properties_;
+  unsigned id_objects_elements_;
+  unsigned id_shared_function_info_;
+  unsigned id_context_;
+  unsigned id_code_relocation_info_;
+  unsigned id_code_deopt_data_;
 };
 
 


### PR DESCRIPTION
Details of the bug fix:
ClassNames::GetConstructorName returned before only the types for JSObject,
but there are a lot of objects, which are created for v8 purposes and which
exist in heap. User need to understand that these objects exist even if he
cannot affect them directly. I have added the v8 service types determination
as well added the detection of cases when type of the service object might be
defined only after analysis of the parent's object. For example the
(object properties) type might be determined only after analyzing of the
parent and check follow conditions: 1. parent is a JSObject 2. the child object
is referred by the parent->properties().

The creation sequence of such dependent object are different and sometimes
children objects are created first, sometimes parents are created first.
To determine the type name correctly we need to make sure that the whole
object is created and start to resolve types only after this.
For making sure that objects are created we have added cyclic buffer
XDKAllocationTracker::latest_allocations_. It is filled until trashold, and
when trashold is achieved we start to pop old objects and resolve them. One pop
for one new allocated object.

There is some gap of objects == trashold which are not resolved, and we decided
to ignore this unresolved tail.
