### PR TITLE
Cherry pick of XDK heap profiler commits and several fixes due to chromium M42 migration

### DIFF
--- a/include/v8-profiler.h
+++ b/include/v8-profiler.h
@@ -143,6 +143,19 @@ class V8_EXPORT CpuProfile {
 
 
 /**
+ * HeapEventXDK contains the latest chunk of heap info
+ */
+class V8_EXPORT HeapEventXDK {
+ public:
+  const char* getSymbols();
+  const char* getFrames();
+  const char* getTypes();
+  const char* getChunks();
+  const char* getRetentions();
+  unsigned int getDuration();
+};
+
+/**
  * Interface for controlling CPU profiling. Instance of the
  * profiler can be retrieved using v8::Isolate::GetCpuProfiler.
  */
@@ -312,6 +325,19 @@ class V8_EXPORT OutputStream {  // NOLINT
    * will not be called in case writing was aborted.
    */
   virtual WriteResult WriteHeapStatsChunk(HeapStatsUpdate* data, int count) {
+    return kAbort;
+  }
+
+
+  /**
+   * Writes XDK object
+   */
+  virtual WriteResult WriteHeapXDKChunk(const char* symbols, int symbolsSize,
+                                        const char* frames, int framesSize,
+                                        const char* types, int typesSize,
+                                        const char* chunks, int chunksSize,
+                                        const char* retentions,
+                                        int retentionSize) {
     return kAbort;
   }
 };
@@ -529,6 +555,14 @@ class V8_EXPORT HeapProfiler {
    * Sets a RetainedObjectInfo for an object group (see V8::SetObjectGroupId).
    */
   void SetRetainedObjectInfo(UniqueId id, RetainedObjectInfo* info);
+
+  void StartTrackingHeapObjectsXDK(int stackDepth, bool retentions,
+      bool strict_collection = false);
+  /**
+   * @author amalyshe
+   */
+  void GetHeapXDKStats(OutputStream* stream);
+  HeapEventXDK* StopTrackingHeapObjectsXDK();
 
  private:
   HeapProfiler();

--- a/src/api.cc
+++ b/src/api.cc
@@ -51,7 +51,7 @@
 #include "src/v8threads.h"
 #include "src/version.h"
 #include "src/vm-state-inl.h"
-
+#include "src/xdk-allocation.h"
 
 #define LOG_API(isolate, expr) LOG(isolate, ApiEntryCall(expr))
 
@@ -7480,6 +7480,47 @@ Handle<String> HeapSnapshot::GetTitle() const {
 }
 
 
+const char* HeapEventXDK::getSymbols() {
+  const i::HeapEventXDK* eventXDK =
+    reinterpret_cast<const i::HeapEventXDK*>(this);
+  return eventXDK->symbols();
+}
+
+
+const char* HeapEventXDK::getFrames() {
+  const i::HeapEventXDK* eventXDK =
+    reinterpret_cast<const i::HeapEventXDK*>(this);
+  return eventXDK->frames();
+}
+
+
+const char* HeapEventXDK::getTypes() {
+  const i::HeapEventXDK* eventXDK =
+    reinterpret_cast<const i::HeapEventXDK*>(this);
+  return eventXDK->types();
+}
+
+
+const char* HeapEventXDK::getChunks() {
+  const i::HeapEventXDK* eventXDK =
+      reinterpret_cast<const i::HeapEventXDK*>(this);
+  return eventXDK->chunks();
+}
+
+
+const char* HeapEventXDK::getRetentions() {
+  const i::HeapEventXDK* eventXDK =
+    reinterpret_cast<const i::HeapEventXDK*>(this);
+  return eventXDK->retentions();
+}
+
+
+unsigned int HeapEventXDK::getDuration() {
+  const i::HeapEventXDK* eventXDK =
+    reinterpret_cast<const i::HeapEventXDK*>(this);
+  return eventXDK->duration();
+}
+
 const HeapGraphNode* HeapSnapshot::GetRoot() const {
   return reinterpret_cast<const HeapGraphNode*>(ToInternal(this)->root());
 }
@@ -7578,6 +7619,24 @@ void HeapProfiler::StopTrackingHeapObjects() {
 
 SnapshotObjectId HeapProfiler::GetHeapStats(OutputStream* stream) {
   return reinterpret_cast<i::HeapProfiler*>(this)->PushHeapObjectsStats(stream);
+}
+
+
+void HeapProfiler::GetHeapXDKStats(OutputStream* stream) {
+  reinterpret_cast<i::HeapProfiler*>(this)->PushHeapObjectsXDKStats(stream);
+}
+
+
+void HeapProfiler::StartTrackingHeapObjectsXDK(int stackDepth,
+    bool retentions, bool strict_collection) {
+  reinterpret_cast<i::HeapProfiler*>(this)->StartHeapObjectsTrackingXDK(
+      stackDepth, retentions, strict_collection);
+}
+
+
+HeapEventXDK* HeapProfiler::StopTrackingHeapObjectsXDK() {
+  return reinterpret_cast<HeapEventXDK*>(
+    reinterpret_cast<i::HeapProfiler*>(this)->StopHeapObjectsTrackingXDK());
 }
 
 

--- a/src/heap-profiler.cc
+++ b/src/heap-profiler.cc
@@ -8,6 +8,7 @@
 
 #include "src/allocation-tracker.h"
 #include "src/heap-snapshot-generator-inl.h"
+#include "src/xdk-allocation.h"
 
 namespace v8 {
 namespace internal {
@@ -68,7 +69,7 @@ HeapSnapshot* HeapProfiler::TakeSnapshot(
     v8::HeapProfiler::ObjectNameResolver* resolver) {
   HeapSnapshot* result = new HeapSnapshot(this, name, next_snapshot_uid_++);
   {
-    HeapSnapshotGenerator generator(result, control, resolver, heap());
+    HeapSnapshotGenerator generator(this, result, control, resolver, heap());
     if (!generator.GenerateSnapshot()) {
       delete result;
       result = NULL;
@@ -115,6 +116,46 @@ void HeapProfiler::StopHeapObjectsTracking() {
 }
 
 
+void HeapProfiler::StartHeapObjectsTrackingXDK(int stackDepth,
+    bool retentions, bool strict_collection) {
+  ids_->UpdateHeapObjectsMap();
+  is_tracking_object_moves_ = true;
+  DCHECK(!is_tracking_allocations());
+  allocation_tracker_xdk_.Reset(new XDKAllocationTracker(this, ids_.get(),
+                                names_.get(), stackDepth, retentions,
+                                strict_collection));
+  heap()->DisableInlineAllocation();
+  // init pre collected objects
+  allocation_tracker_xdk_->CollectFreedObjects(false, true);
+}
+
+
+void HeapProfiler::PushHeapObjectsXDKStats(OutputStream* stream) {
+  // get the garbage here
+  if (!allocation_tracker_xdk_.is_empty()) {
+    allocation_tracker_xdk_->CollectFreedObjects();
+    OutputStream::WriteResult result =
+        allocation_tracker_xdk_->SendChunk(stream);
+    // TODO(amalyshe): it's interesting why CDT can return kAbort. Need to
+    // investigate if we need add better error generation in the
+    // allocation_tracker_xdk_->SendChunk
+    if (result == OutputStream::kAbort) return;
+    stream->EndOfStream();
+  }
+}
+
+
+v8::internal::HeapEventXDK* HeapProfiler::StopHeapObjectsTrackingXDK() {
+  HeapEventXDK* event = NULL;
+  if (!allocation_tracker_xdk_.is_empty()) {
+    event = allocation_tracker_xdk_->stopTracking();
+    allocation_tracker_xdk_.Reset(NULL);
+    heap()->EnableInlineAllocation();
+  }
+  return event;
+}
+
+
 size_t HeapProfiler::GetMemorySizeUsedByProfiler() {
   size_t size = sizeof(*this);
   size += names_->GetUsedMemorySize();
@@ -145,9 +186,13 @@ SnapshotObjectId HeapProfiler::GetSnapshotObjectId(Handle<Object> obj) {
 
 
 void HeapProfiler::ObjectMoveEvent(Address from, Address to, int size) {
-  bool known_object = ids_->MoveObject(from, to, size);
-  if (!known_object && !allocation_tracker_.is_empty()) {
-    allocation_tracker_->address_to_trace()->MoveObject(from, to, size);
+  if (allocation_tracker_xdk_.is_empty()) {
+    bool known_object = ids_->MoveObject(from, to, size);
+    if (!known_object && !allocation_tracker_.is_empty()) {
+      allocation_tracker_->address_to_trace()->MoveObject(from, to, size);
+    }
+  } else {
+    allocation_tracker_xdk_->OnMove(from, to, size);
   }
 }
 
@@ -156,6 +201,9 @@ void HeapProfiler::AllocationEvent(Address addr, int size) {
   DisallowHeapAllocation no_allocation;
   if (!allocation_tracker_.is_empty()) {
     allocation_tracker_->AllocationEvent(addr, size);
+  }
+  if (!allocation_tracker_xdk_.is_empty()) {
+    allocation_tracker_xdk_->OnAlloc(addr, size);
   }
 }
 

--- a/src/heap-profiler.h
+++ b/src/heap-profiler.h
@@ -13,6 +13,7 @@ namespace v8 {
 namespace internal {
 
 class HeapSnapshot;
+class HeapEventXDK;
 
 class HeapProfiler {
  public:
@@ -39,6 +40,11 @@ class HeapProfiler {
   StringsStorage* names() const { return names_.get(); }
 
   SnapshotObjectId PushHeapObjectsStats(OutputStream* stream);
+  void PushHeapObjectsXDKStats(OutputStream* stream);
+  void StartHeapObjectsTrackingXDK(int stackDepth, bool retentions,
+      bool strict_collection = false);
+  v8::internal::HeapEventXDK* StopHeapObjectsTrackingXDK();
+
   int GetSnapshotsCount();
   HeapSnapshot* GetSnapshot(int index);
   SnapshotObjectId GetSnapshotObjectId(Handle<Object> obj);
@@ -60,7 +66,8 @@ class HeapProfiler {
 
   bool is_tracking_object_moves() const { return is_tracking_object_moves_; }
   bool is_tracking_allocations() const {
-    return !allocation_tracker_.is_empty();
+    return (!allocation_tracker_.is_empty() ||
+        !allocation_tracker_xdk_.is_empty());
   }
 
   Handle<HeapObject> FindHeapObjectById(SnapshotObjectId id);
@@ -76,6 +83,7 @@ class HeapProfiler {
   unsigned next_snapshot_uid_;
   List<v8::HeapProfiler::WrapperInfoCallback> wrapper_callbacks_;
   SmartPointer<AllocationTracker> allocation_tracker_;
+  SmartPointer<XDKAllocationTracker> allocation_tracker_xdk_;
   bool is_tracking_object_moves_;
 };
 

--- a/src/heap-snapshot-generator-inl.h
+++ b/src/heap-snapshot-generator-inl.h
@@ -22,7 +22,7 @@ HeapSnapshot* HeapGraphEdge::snapshot() const {
 
 
 int HeapEntry::index() const {
-  return static_cast<int>(this - &snapshot_->entries().first());
+  return static_cast<int>(this - &entries_->first());
 }
 
 

--- a/src/heap-snapshot-generator.cc
+++ b/src/heap-snapshot-generator.cc
@@ -45,6 +45,7 @@ void HeapGraphEdge::ReplaceToIndexWithEntry(HeapSnapshot* snapshot) {
 const int HeapEntry::kNoEntry = -1;
 
 HeapEntry::HeapEntry(HeapSnapshot* snapshot,
+                     const List<HeapEntry>* entries,
                      Type type,
                      const char* name,
                      SnapshotObjectId id,
@@ -55,6 +56,7 @@ HeapEntry::HeapEntry(HeapSnapshot* snapshot,
       children_index_(-1),
       self_size_(self_size),
       snapshot_(snapshot),
+      entries_(entries),
       name_(name),
       id_(id),
       trace_node_id_(trace_node_id) { }
@@ -167,12 +169,16 @@ template <size_t ptr_size> struct SnapshotSizeConstants;
 
 template <> struct SnapshotSizeConstants<4> {
   static const int kExpectedHeapGraphEdgeSize = 12;
-  static const int kExpectedHeapEntrySize = 28;
+  // This variable reflects the size of the HeapEntry structure
+  // it is increased to the 4 bytes in case of 32bit arch and for
+  // 8 bytes for 64 bit arch because for isolating HeapEntry from
+  // snapshot we need to add one more pointer to the List* entries_
+  static const int kExpectedHeapEntrySize = 32;
 };
 
 template <> struct SnapshotSizeConstants<8> {
   static const int kExpectedHeapGraphEdgeSize = 24;
-  static const int kExpectedHeapEntrySize = 40;
+  static const int kExpectedHeapEntrySize = 48;
 };
 
 }  // namespace
@@ -267,7 +273,7 @@ HeapEntry* HeapSnapshot::AddEntry(HeapEntry::Type type,
                                   SnapshotObjectId id,
                                   size_t size,
                                   unsigned trace_node_id) {
-  HeapEntry entry(this, type, name, id, size, trace_node_id);
+  HeapEntry entry(this, &this->entries(), type, name, id, size, trace_node_id);
   entries_.Add(entry);
   return &entries_.last();
 }
@@ -777,13 +783,14 @@ void HeapObjectsSet::SetTag(Object* obj, const char* tag) {
 
 
 V8HeapExplorer::V8HeapExplorer(
+    HeapProfiler* profiler,
     HeapSnapshot* snapshot,
     SnapshottingProgressReportingInterface* progress,
     v8::HeapProfiler::ObjectNameResolver* resolver)
-    : heap_(snapshot->profiler()->heap_object_map()->heap()),
+    : heap_(profiler->heap_object_map()->heap()),
       snapshot_(snapshot),
-      names_(snapshot_->profiler()->names()),
-      heap_object_map_(snapshot_->profiler()->heap_object_map()),
+      names_(profiler->names()),
+      heap_object_map_(profiler->heap_object_map()),
       progress_(progress),
       filler_(NULL),
       global_object_name_resolver_(resolver) {
@@ -889,12 +896,13 @@ HeapEntry* V8HeapExplorer::AddEntry(Address address,
 }
 
 
-class SnapshotFiller {
+class CDTSnapshotFiller: public SnapshotFiller {
  public:
-  explicit SnapshotFiller(HeapSnapshot* snapshot, HeapEntriesMap* entries)
+  explicit CDTSnapshotFiller(HeapSnapshot* snapshot, HeapEntriesMap* entries)
       : snapshot_(snapshot),
         names_(snapshot->profiler()->names()),
         entries_(entries) { }
+  virtual ~CDTSnapshotFiller() {}
   HeapEntry* AddEntry(HeapThing ptr, HeapEntriesAllocator* allocator) {
     HeapEntry* entry = allocator->AllocateEntry(ptr);
     entries_->Pair(ptr, entry->index());
@@ -1826,11 +1834,15 @@ bool V8HeapExplorer::IterateAndExtractReferences(
   // Make sure builtin code objects get their builtin tags
   // first. Otherwise a particular JSFunction object could set
   // its custom name to a generic builtin.
-  RootsReferencesExtractor extractor(heap_);
-  heap_->IterateRoots(&extractor, VISIT_ONLY_STRONG);
-  extractor.SetCollectingAllReferences();
-  heap_->IterateRoots(&extractor, VISIT_ALL);
-  extractor.FillReferences(this);
+  // TODO(amalyshe): this condition should be refactored for catching
+  // root extractor
+  if (snapshot_) {
+    RootsReferencesExtractor extractor(heap_);
+    heap_->IterateRoots(&extractor, VISIT_ONLY_STRONG);
+    extractor.SetCollectingAllReferences();
+    heap_->IterateRoots(&extractor, VISIT_ALL);
+    extractor.FillReferences(this);
+  }
 
   // We have to do two passes as sometimes FixedArrays are used
   // to weakly hold their items, and it's impossible to distinguish
@@ -2070,10 +2082,12 @@ void V8HeapExplorer::SetPropertyReference(HeapObject* parent_obj,
 
 
 void V8HeapExplorer::SetRootGcRootsReference() {
-  filler_->SetIndexedAutoIndexReference(
-      HeapGraphEdge::kElement,
-      snapshot_->root()->index(),
-      snapshot_->gc_roots());
+  if (snapshot_) {
+    filler_->SetIndexedAutoIndexReference(
+        HeapGraphEdge::kElement,
+        snapshot_->root()->index(),
+        snapshot_->gc_roots());
+  }
 }
 
 
@@ -2088,10 +2102,12 @@ void V8HeapExplorer::SetUserGlobalReference(Object* child_obj) {
 
 
 void V8HeapExplorer::SetGcRootsReference(VisitorSynchronization::SyncTag tag) {
-  filler_->SetIndexedAutoIndexReference(
-      HeapGraphEdge::kElement,
-      snapshot_->gc_roots()->index(),
-      snapshot_->gc_subroot(tag));
+  if (snapshot_) {
+    filler_->SetIndexedAutoIndexReference(
+        HeapGraphEdge::kElement,
+        snapshot_->gc_roots()->index(),
+        snapshot_->gc_subroot(tag));
+  }
 }
 
 
@@ -2249,11 +2265,12 @@ class GlobalHandlesExtractor : public ObjectVisitor {
 class BasicHeapEntriesAllocator : public HeapEntriesAllocator {
  public:
   BasicHeapEntriesAllocator(
+      HeapProfiler* profiler,
       HeapSnapshot* snapshot,
       HeapEntry::Type entries_type)
     : snapshot_(snapshot),
-      names_(snapshot_->profiler()->names()),
-      heap_object_map_(snapshot_->profiler()->heap_object_map()),
+      names_(profiler->names()),
+      heap_object_map_(profiler->heap_object_map()),
       entries_type_(entries_type) {
   }
   virtual HeapEntry* AllocateEntry(HeapThing ptr);
@@ -2283,19 +2300,20 @@ HeapEntry* BasicHeapEntriesAllocator::AllocateEntry(HeapThing ptr) {
 
 
 NativeObjectsExplorer::NativeObjectsExplorer(
+    HeapProfiler* profiler,
     HeapSnapshot* snapshot,
     SnapshottingProgressReportingInterface* progress)
-    : isolate_(snapshot->profiler()->heap_object_map()->heap()->isolate()),
+    : isolate_(profiler->heap_object_map()->heap()->isolate()),
       snapshot_(snapshot),
-      names_(snapshot_->profiler()->names()),
+      names_(profiler->names()),
       embedder_queried_(false),
       objects_by_info_(RetainedInfosMatch),
       native_groups_(StringsMatch),
       filler_(NULL) {
   synthetic_entries_allocator_ =
-      new BasicHeapEntriesAllocator(snapshot, HeapEntry::kSynthetic);
+      new BasicHeapEntriesAllocator(profiler, snapshot, HeapEntry::kSynthetic);
   native_entries_allocator_ =
-      new BasicHeapEntriesAllocator(snapshot, HeapEntry::kNative);
+      new BasicHeapEntriesAllocator(profiler, snapshot, HeapEntry::kNative);
 }
 
 
@@ -2523,15 +2541,18 @@ void NativeObjectsExplorer::VisitSubtreeWrapper(Object** p, uint16_t class_id) {
 
 
 HeapSnapshotGenerator::HeapSnapshotGenerator(
+    HeapProfiler* profiler,
     HeapSnapshot* snapshot,
     v8::ActivityControl* control,
     v8::HeapProfiler::ObjectNameResolver* resolver,
-    Heap* heap)
+    Heap* heap,
+    SnapshotFiller* filler)
     : snapshot_(snapshot),
       control_(control),
-      v8_heap_explorer_(snapshot_, this, resolver),
-      dom_explorer_(snapshot_, this),
-      heap_(heap) {
+      v8_heap_explorer_(profiler, snapshot_, this, resolver),
+      dom_explorer_(profiler, snapshot_, this),
+      heap_(heap),
+      filler_(filler) {
 }
 
 
@@ -2564,12 +2585,16 @@ bool HeapSnapshotGenerator::GenerateSnapshot() {
   }
 #endif
 
-  snapshot_->AddSyntheticRootEntries();
+  if (snapshot_) {
+    snapshot_->AddSyntheticRootEntries();
+  }
 
   if (!FillReferences()) return false;
 
-  snapshot_->FillChildren();
-  snapshot_->RememberLastJSObjectId();
+  if (snapshot_) {
+    snapshot_->FillChildren();
+    snapshot_->RememberLastJSObjectId();
+  }
 
   progress_counter_ = progress_total_;
   if (!ProgressReport(true)) return false;
@@ -2605,9 +2630,16 @@ void HeapSnapshotGenerator::SetProgressTotal(int iterations_count) {
 
 
 bool HeapSnapshotGenerator::FillReferences() {
-  SnapshotFiller filler(snapshot_, &entries_);
-  return v8_heap_explorer_.IterateAndExtractReferences(&filler)
-      && dom_explorer_.IterateAndExtractReferences(&filler);
+  if (!filler_) {
+    CDTSnapshotFiller filler(snapshot_, &entries_);
+    return v8_heap_explorer_.IterateAndExtractReferences(&filler)
+        && dom_explorer_.IterateAndExtractReferences(&filler);
+  } else {
+    // TODO(amalyshe): finally this need to be returned back when XDK heap
+    // profiler supports toot extractor
+    // v8_heap_explorer_.AddRootEntries(filler_);
+    return v8_heap_explorer_.IterateAndExtractReferences(filler_);
+  }
 }
 
 

--- a/src/heap-snapshot-generator.h
+++ b/src/heap-snapshot-generator.h
@@ -11,6 +11,7 @@ namespace v8 {
 namespace internal {
 
 class AllocationTracker;
+class XDKAllocationTracker;
 class AllocationTraceNode;
 class HeapEntry;
 class HeapSnapshot;
@@ -88,6 +89,7 @@ class HeapEntry BASE_EMBEDDED {
 
   HeapEntry() { }
   HeapEntry(HeapSnapshot* snapshot,
+            const List<HeapEntry>* entries,
             Type type,
             const char* name,
             SnapshotObjectId id,
@@ -127,6 +129,7 @@ class HeapEntry BASE_EMBEDDED {
   int children_index_;
   size_t self_size_;
   HeapSnapshot* snapshot_;
+  const List<HeapEntry>* entries_;
   const char* name_;
   SnapshotObjectId id_;
   // id of allocation stack trace top node
@@ -320,11 +323,36 @@ class SnapshottingProgressReportingInterface {
   virtual bool ProgressReport(bool force) = 0;
 };
 
+class SnapshotFiller {
+ public:
+  virtual ~SnapshotFiller() {}
+
+  virtual HeapEntry* AddEntry(HeapThing ptr,
+                              HeapEntriesAllocator* allocator) = 0;
+  virtual HeapEntry* FindEntry(HeapThing ptr) = 0;
+  virtual HeapEntry* FindOrAddEntry(HeapThing ptr,
+                                    HeapEntriesAllocator* allocator) = 0;
+  virtual void SetIndexedReference(HeapGraphEdge::Type type,
+                           int parent,
+                           int index,
+                           HeapEntry* child_entry) = 0;
+  virtual void SetIndexedAutoIndexReference(HeapGraphEdge::Type type,
+                                    int parent,
+                                    HeapEntry* child_entry) = 0;
+  virtual void SetNamedReference(HeapGraphEdge::Type type,
+                         int parent,
+                         const char* reference_name,
+                         HeapEntry* child_entry) = 0;
+  virtual void SetNamedAutoIndexReference(HeapGraphEdge::Type type,
+                                  int parent,
+                                  HeapEntry* child_entry) = 0;
+};
 
 // An implementation of V8 heap graph extractor.
 class V8HeapExplorer : public HeapEntriesAllocator {
  public:
-  V8HeapExplorer(HeapSnapshot* snapshot,
+  V8HeapExplorer(HeapProfiler* profiler,
+                 HeapSnapshot* snapshot,
                  SnapshottingProgressReportingInterface* progress,
                  v8::HeapProfiler::ObjectNameResolver* resolver);
   virtual ~V8HeapExplorer();
@@ -472,7 +500,8 @@ class NativeGroupRetainedObjectInfo;
 // An implementation of retained native objects extractor.
 class NativeObjectsExplorer {
  public:
-  NativeObjectsExplorer(HeapSnapshot* snapshot,
+  NativeObjectsExplorer(HeapProfiler* profiler,
+                        HeapSnapshot* snapshot,
                         SnapshottingProgressReportingInterface* progress);
   virtual ~NativeObjectsExplorer();
   int EstimateObjectsCount();
@@ -527,10 +556,12 @@ class NativeObjectsExplorer {
 
 class HeapSnapshotGenerator : public SnapshottingProgressReportingInterface {
  public:
-  HeapSnapshotGenerator(HeapSnapshot* snapshot,
+  HeapSnapshotGenerator(HeapProfiler* profiler,
+                        HeapSnapshot* snapshot,
                         v8::ActivityControl* control,
                         v8::HeapProfiler::ObjectNameResolver* resolver,
-                        Heap* heap);
+                        Heap* heap,
+                        SnapshotFiller* filler = NULL);
   bool GenerateSnapshot();
 
  private:
@@ -549,6 +580,7 @@ class HeapSnapshotGenerator : public SnapshottingProgressReportingInterface {
   int progress_counter_;
   int progress_total_;
   Heap* heap_;
+  SnapshotFiller* filler_;
 
   DISALLOW_COPY_AND_ASSIGN(HeapSnapshotGenerator);
 };

--- a/src/xdk-allocation.cc
+++ b/src/xdk-allocation.cc
@@ -1,0 +1,578 @@
+// Copyright 2014 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <sstream>
+#include <string>
+
+#include "src/v8.h"
+
+#include "src/xdk-allocation.h"
+
+#include "frames-inl.h"
+#include "src/xdk-utils.h"
+
+namespace v8 {
+namespace internal {
+
+static List<InfoToResolve>* g_la_list = NULL;
+void XDKGCPrologueCallback(v8::Isolate*, GCType, GCCallbackFlags) {
+  if (g_la_list) {
+    g_la_list->Clear();
+  }
+}
+
+
+XDKAllocationTracker::XDKAllocationTracker(HeapProfiler* heap_profiler,
+                                           HeapObjectsMap *ids,
+                                           StringsStorage *names,
+                                           int stackDepth,
+                                           bool collectRetention,
+                                           bool strict_collection)
+    : heap_profiler_(heap_profiler),
+    ids_(ids),
+    names_(names),
+    stackDepth_(stackDepth),
+    collectRetention_(collectRetention),
+    strict_collection_(strict_collection),
+    a_treshold_(50),
+    a_current_(0) {
+  references_ = new References();
+  aggregated_chunks_ = new AggregatedChunks();
+  runtime_info_ = new RuntimeInfo(aggregated_chunks_);
+  symbols_ = new SymbolsStorage(ids_->heap(), names_);
+  collectedStacks_ = new ShadowStack();
+  classNames_ = new ClassNames(names_, ids_->heap());
+
+  List<unsigned> stack_ooc;
+  stack_ooc.Add(symbols_->registerSymInfo(1, "OutOfContext", "NoSource",
+                                          0, 0));
+  outOfContextFrame_ = collectedStacks_->registerStack(stack_ooc);
+
+  List<unsigned> stack_abc;
+  stack_abc.Add(symbols_->registerSymInfo(2, "AllocatedBeforeCollection",
+                                          "NoSource", 0, 0));
+  AllocatedBeforeCollectionFrame_ = collectedStacks_->registerStack(stack_abc);
+
+  runtime_info_->InitABCFrame(AllocatedBeforeCollectionFrame_);
+
+  baseTime_ = v8::base::Time::Now();
+  latest_delta_ = 0;
+
+  g_la_list = &this->latest_allocations_;
+  v8::Isolate::GCPrologueCallback e =
+      (v8::Isolate::GCPrologueCallback) &XDKGCPrologueCallback;
+  ids_->heap()->AddGCPrologueCallback(e, kGCTypeAll, false);
+}
+
+
+XDKAllocationTracker::~XDKAllocationTracker() {
+  delete collectedStacks_;
+  delete classNames_;
+  delete aggregated_chunks_;
+  delete runtime_info_;
+  delete symbols_;
+  delete references_;
+  g_la_list = NULL;
+}
+
+
+// Heap profiler regularly takes time for storing when object was allocated,
+// deallocated, when object's retention snapshot was taken, etc
+unsigned int XDKAllocationTracker::GetTimeDelta() {
+  v8::base::TimeDelta td = v8::base::Time::Now() - baseTime_;
+  return static_cast<unsigned int>(td.InMilliseconds());
+}
+
+
+void XDKAllocationTracker::OnAlloc(Address addr, int size) {
+  DisallowHeapAllocation no_alloc;
+  Heap *heap = ids_->heap();
+
+  // below call saves from the crash during StackTraceFrameIterator creation
+  // Mark the new block as FreeSpace to make sure the heap is iterable
+  // while we are capturing stack trace.
+  heap->CreateFillerObjectAt(addr, size);
+
+  Isolate *isolate = heap->isolate();
+  StackTraceFrameIterator it(isolate);
+  List<unsigned> stack;
+
+  // TODO(amalyshe): checking of isolate->handle_scope_data()->level is quite
+  // artificial. need to understand when we can have such behaviour
+  // if level == 0 we will crash in getting of source info
+  while (isolate->handle_scope_data()->level && !it.done() &&
+      stack.length() < stackDepth_) {
+    JavaScriptFrame *frame = it.frame();
+    if (!frame->function())
+      break;
+    SharedFunctionInfo *shared = frame->function()->shared();
+    if (!shared)
+      break;
+
+    stack.Add(symbols_->FindOrRegisterFrame(frame));
+    it.Advance();
+  }
+
+  unsigned sid;
+  if (!stack.is_empty()) {
+    sid = collectedStacks_->registerStack(stack);
+  } else {
+    sid = outOfContextFrame_;
+  }
+
+  latest_delta_ = GetTimeDelta();
+
+  PostCollectedInfo* info = runtime_info_->AddPostCollectedInfo(addr,
+                                                                latest_delta_);
+  info->size_ = size;
+  info->timeStamp_ = latest_delta_;
+  info->stackId_ = sid;
+  info->className_ = (unsigned int)-1;
+  info->dirty_ = false;
+
+  // init the type info for previous allocated object
+  if (latest_allocations_.length() == a_treshold_) {
+    // resolve next allocation to process
+    InfoToResolve& allocation = latest_allocations_.at(a_current_);
+    InitClassName(allocation.address_, allocation.info_);
+    a_current_++;
+    if (a_current_ >= a_treshold_) {
+      a_current_ = 0;
+    }
+  }
+
+  if (latest_allocations_.length() < a_treshold_) {
+    InfoToResolve allocation;
+    allocation.address_ = addr;
+    allocation.info_ = info;
+    latest_allocations_.Add(allocation);
+  } else {
+    unsigned allocation_to_update =
+        a_current_ ? a_current_ - 1 : a_treshold_ - 1;
+    InfoToResolve& allocation =
+        latest_allocations_.at(allocation_to_update);
+    allocation.address_ = addr;
+    allocation.info_ = info;
+  }
+}
+
+
+void XDKAllocationTracker::OnMove(Address from, Address to, int size) {
+  DisallowHeapAllocation no_alloc;
+  // look for the prev address
+  PostCollectedInfo* info_from = runtime_info_->FindPostCollectedInfo(from);
+  if (info_from == NULL) {
+    return;
+  }
+
+  runtime_info_->AddPostCollectedInfo(to, latest_delta_, info_from);
+  runtime_info_->RemoveInfo(from);
+}
+
+
+HeapEventXDK* XDKAllocationTracker::stopTracking() {
+  std::string symbols, types, frames, chunks, retentions;
+  SerializeChunk(&symbols, &types, &frames, &chunks, &retentions);
+  CollectFreedObjects(true);
+  std::string symbolsA, typesA, framesA, chunksA, retentionsA;
+  SerializeChunk(&symbolsA, &typesA, &framesA, &chunksA, &retentionsA, true);
+
+  // TODO(amalyshe): check who releases this object - new HeapEventXDK
+  return (new HeapEventXDK(GetTimeDelta(), symbols+symbolsA, types+typesA,
+      frames+framesA, chunks+chunksA, ""));
+}
+
+
+void XDKAllocationTracker::CollectFreedObjects(bool bAll, bool initPreCollect) {
+  clearIndividualReteiners();
+  if (collectRetention_) {
+    XDKSnapshotFiller filler(ids_, names_, this);
+    HeapSnapshotGenerator generator(heap_profiler_, NULL, NULL, NULL,
+                                    ids_->heap(), &filler);
+    generator.GenerateSnapshot();
+  }
+
+  Heap *heap = ids_->heap();
+  if (!heap) {
+    return;
+  }
+
+  unsigned int ts = GetTimeDelta();
+  if (bAll) {
+    ts += RETAINED_DELTA;
+  }
+
+  // CDT heap profiler calls CollectAllGarbage twice because after the first
+  // pass there are weak retained object not collected, but due to perf issues
+  // and because we do garbage collection regularly, we leave here only one call
+  // only for strict collection like in test where we need to make sure that
+  // object is definitely collected, we collect twice
+  heap->CollectAllGarbage(
+      Heap::kMakeHeapIterableMask,
+      "XDKAllocationTracker::CollectFreedObjects");
+  if (strict_collection_) {
+    heap->CollectAllGarbage(
+        Heap::kMakeHeapIterableMask,
+        "XDKAllocationTracker::CollectFreedObjects");
+  }
+  std::map<Address, RefSet> individualReteiners;
+
+  // TODO(amalyshe): check what DisallowHeapAllocation no_alloc means because in
+  // standalone v8 this part is crashed if DisallowHeapAllocation is defined
+  // DisallowHeapAllocation no_alloc;
+  if (!bAll) {
+    HeapIterator iterator(heap);
+    HeapObject* obj = iterator.next();
+    for (;
+         obj != NULL;
+         obj = iterator.next()) {
+      Address addr = obj->address();
+
+      PostCollectedInfo* info = runtime_info_->FindPostCollectedInfo(addr);
+      if (!info) {
+        // if we don't find info, we consider it as pre collection allocated
+        // object. need to add to the full picture for retentions
+        if (initPreCollect) {
+          info = runtime_info_->AddPreCollectionInfo(addr, obj->Size());
+        }
+      }
+
+      if (info) {
+        info->dirty_ = true;
+      }
+      // check of the class name and its initialization
+      if ((info && info->className_ == (unsigned)-1) || !info) {
+        InitClassName(addr, ts, obj->Size());
+      }
+    }
+  }
+
+  if (collectRetention_) {
+    std::map<Address, RefSet>::const_iterator citir =
+        individualReteiners_.begin();
+    while (citir != individualReteiners_.end()) {
+      PostCollectedInfo* infoChild =
+          runtime_info_->FindPostCollectedInfo(citir->first);
+      if (infoChild) {
+        RefId rfId;
+        rfId.stackId_ = infoChild->stackId_;
+        rfId.classId_ = infoChild->className_;
+
+        references_->addReference(rfId, citir->second, infoChild->timeStamp_);
+      }
+      citir++;
+    }
+  }
+
+  runtime_info_->CollectGarbaged(ts);
+}
+
+
+void XDKAllocationTracker::SerializeChunk(std::string* symbols,
+                                          std::string* types,
+                                          std::string* frames,
+                                          std::string* chunks,
+                                          std::string* retentions,
+                                          bool final) {
+  if (final) {
+    *symbols = symbols_->SerializeChunk();
+    *types = classNames_->SerializeChunk();
+  }
+  *frames = collectedStacks_->SerializeChunk();
+  *chunks = aggregated_chunks_->SerializeChunk();
+
+  *retentions = references_->serialize();
+  std::stringstream retentionsT;
+  retentionsT << GetTimeDelta() << std::endl << retentions->c_str();
+  *retentions = retentionsT.str();
+  references_->clear();
+}
+
+
+OutputStream::WriteResult XDKAllocationTracker::SendChunk(
+    OutputStream* stream) {
+  // go over all aggregated_ and send data to the stream
+  std::string symbols, types, frames, chunks, retentions;
+  SerializeChunk(&symbols, &types, &frames, &chunks, &retentions);
+
+  OutputStream::WriteResult ret = stream->WriteHeapXDKChunk(
+      symbols.c_str(), symbols.length(),
+      frames.c_str(), frames.length(),
+      types.c_str(), types.length(),
+      chunks.c_str(), chunks.length(),
+      retentions.c_str(), retentions.length());
+  return ret;
+}
+
+
+unsigned XDKAllocationTracker::GetTraceNodeId(Address address) {
+    PostCollectedInfo* info = runtime_info_->FindPostCollectedInfo(address);
+    if (info) {
+      return info->stackId_;
+    } else {
+      return AllocatedBeforeCollectionFrame_;
+    }
+}
+
+
+void XDKAllocationTracker::clearIndividualReteiners() {
+  individualReteiners_.clear();
+}
+
+
+std::map<Address, RefSet>* XDKAllocationTracker::GetIndividualReteiners() {
+  return &individualReteiners_;
+}
+
+
+unsigned XDKAllocationTracker::FindClassName(Address address) {
+  PostCollectedInfo* info = runtime_info_->FindPostCollectedInfo(address);
+  if (info) {
+    return info->className_;
+  } else {
+    return (unsigned)-1;
+  }
+}
+
+
+unsigned XDKAllocationTracker::InitClassName(Address address,
+                                             PostCollectedInfo* info) {
+  if (info->className_ == (unsigned)-1) {
+    info->className_ = classNames_->GetConstructorName(address, runtime_info_);
+  }
+  return info->className_;
+}
+
+unsigned XDKAllocationTracker::InitClassName(Address address, unsigned ts,
+                                             unsigned size) {
+  PostCollectedInfo* info = runtime_info_->FindPostCollectedInfo(address);
+  if (!info) {
+    info = runtime_info_->AddPostCollectedInfo(address, ts);
+    info->className_ = -1;
+    info->stackId_ = outOfContextFrame_;
+    info->timeStamp_ = ts;
+    info->size_ = size;
+  }
+  return InitClassName(address, info);
+}
+
+
+unsigned XDKAllocationTracker::FindOrInitClassName(Address address,
+                                                   unsigned ts) {
+  unsigned id = FindClassName(address);
+  if (id == (unsigned)-1) {
+    // TODO(amalyshe) check if 0 size here is appropriate
+    id = InitClassName(address, ts, 0);
+  }
+  return id;
+}
+
+
+// -----------------------------------------------------------------------------
+// this is almost a copy and duplication of
+// V8HeapExplorer::AddEntry. refactoring is impossible because
+// heap-snapshot-generator rely on it's structure which is not fully suitable
+// for us.
+HeapEntry* XDKSnapshotFiller::AddEntry(HeapThing ptr,
+                                       HeapEntriesAllocator* allocator) {
+  HeapObject* object = reinterpret_cast<HeapObject*>(ptr);
+  if (object->IsJSFunction()) {
+    JSFunction* func = JSFunction::cast(object);
+    SharedFunctionInfo* shared = func->shared();
+    const char* name = shared->bound() ? "native_bind" :
+        names_->GetName(String::cast(shared->name()));
+    return AddEntry(ptr, object, HeapEntry::kClosure, name);
+  } else if (object->IsJSRegExp()) {
+    JSRegExp* re = JSRegExp::cast(object);
+    return AddEntry(ptr, object,
+                    HeapEntry::kRegExp,
+                    names_->GetName(re->Pattern()));
+  } else if (object->IsJSObject()) {
+    return AddEntry(ptr, object, HeapEntry::kObject, "");
+  } else if (object->IsString()) {
+    String* string = String::cast(object);
+    if (string->IsConsString())
+      return AddEntry(ptr, object,
+                      HeapEntry::kConsString,
+                      "(concatenated string)");
+    if (string->IsSlicedString())
+      return AddEntry(ptr, object,
+                      HeapEntry::kSlicedString,
+                      "(sliced string)");
+    return AddEntry(ptr, object,
+                    HeapEntry::kString,
+                    names_->GetName(String::cast(object)));
+  } else if (object->IsSymbol()) {
+    return AddEntry(ptr, object, HeapEntry::kSymbol, "symbol");
+  } else if (object->IsCode()) {
+    return AddEntry(ptr, object, HeapEntry::kCode, "");
+  } else if (object->IsSharedFunctionInfo()) {
+    String* name = String::cast(SharedFunctionInfo::cast(object)->name());
+    return AddEntry(ptr, object,
+                    HeapEntry::kCode,
+                    names_->GetName(name));
+  } else if (object->IsScript()) {
+    Object* name = Script::cast(object)->name();
+    return AddEntry(ptr, object,
+                    HeapEntry::kCode,
+                    name->IsString()
+                        ? names_->GetName(String::cast(name))
+                        : "");
+  } else if (object->IsNativeContext()) {
+    return AddEntry(ptr, object, HeapEntry::kHidden, "system / NativeContext");
+  } else if (object->IsContext()) {
+    return AddEntry(ptr, object, HeapEntry::kObject, "system / Context");
+  } else if (object->IsFixedArray() ||
+             object->IsFixedDoubleArray() ||
+             object->IsByteArray() ||
+             object->IsExternalArray()) {
+    return AddEntry(ptr, object, HeapEntry::kArray, "");
+  } else if (object->IsHeapNumber()) {
+    return AddEntry(ptr, object, HeapEntry::kHeapNumber, "number");
+  }
+
+  return AddEntry(ptr, object, HeapEntry::kHidden, "system / NOT SUPORTED YET");
+}
+
+
+HeapEntry* XDKSnapshotFiller::AddEntry(HeapThing thing,
+                    HeapObject* object,
+                    HeapEntry::Type type,
+                    const char* name) {
+  Address address = object->address();
+  unsigned trace_node_id = 0;
+  trace_node_id = allocation_tracker_->GetTraceNodeId(address);
+
+  // cannot store pointer in the map because List reallcoates content regularly
+  // and the only  one way to find the entry - by index. so, index is cached in
+  // the map
+  // TODO(amalyshe): need to reuse type. it seems it is important
+  HeapEntry entry(NULL, &heap_entries_list_, type, name, 0, 0,
+                  trace_node_id);
+  heap_entries_list_.Add(entry);
+  HeapEntry* pEntry = &heap_entries_list_.last();
+
+  HashMap::Entry* cache_entry = heap_entries_.Lookup(thing, Hash(thing), true);
+  DCHECK(cache_entry->value == NULL);
+  int index = pEntry->index();
+  cache_entry->value = reinterpret_cast<void*>(static_cast<intptr_t>(index));
+
+  // TODO(amalyshe): it seems this storage might be optimized
+  HashMap::Entry* address_entry = index_to_address_.Lookup(
+      reinterpret_cast<void*>(index+1), HashInt(index+1), true);
+  address_entry->value = reinterpret_cast<void*>(address);
+
+  return pEntry;
+}
+
+
+HeapEntry* XDKSnapshotFiller::FindEntry(HeapThing thing) {
+  HashMap::Entry* cache_entry = heap_entries_.Lookup(thing, Hash(thing), false);
+  if (cache_entry == NULL) return NULL;
+  return &heap_entries_list_[static_cast<int>(
+      reinterpret_cast<intptr_t>(cache_entry->value))];
+}
+
+
+HeapEntry* XDKSnapshotFiller::FindOrAddEntry(HeapThing ptr,
+                                             HeapEntriesAllocator* allocator) {
+  HeapEntry* entry = FindEntry(ptr);
+  return entry != NULL ? entry : AddEntry(ptr, allocator);
+}
+
+
+void XDKSnapshotFiller::SetIndexedReference(HeapGraphEdge::Type type,
+    int parent,
+    int index,
+    HeapEntry* child_entry) {
+  if (child_entry->trace_node_id() < 3) {
+    return;
+  }
+  HashMap::Entry* address_entry_child = index_to_address_.Lookup(
+      reinterpret_cast<void*>(child_entry->index()+1),
+      HashInt(child_entry->index()+1), false);
+  DCHECK(address_entry_child != NULL);
+  if (!address_entry_child) {
+    return;
+  }
+
+  Address child_addr = reinterpret_cast<Address>(address_entry_child->value);
+
+  std::map<Address, RefSet>* individualReteiners =
+      allocation_tracker_->GetIndividualReteiners();
+  // get the parent's address, constructor name and form the RefId
+  HashMap::Entry* address_entry = index_to_address_.Lookup(
+      reinterpret_cast<void*>(parent+1), HashInt(parent+1), false);
+  DCHECK(address_entry != NULL);
+  if (!address_entry) {
+    return;
+  }
+  HeapEntry* parent_entry = &(heap_entries_list_[parent]);
+  Address parent_addr = reinterpret_cast<Address>(address_entry->value);
+  RefId parent_ref_id;
+  parent_ref_id.stackId_ = parent_entry->trace_node_id();
+  parent_ref_id.classId_ =
+      allocation_tracker_->FindOrInitClassName(parent_addr, 0);
+
+  std::stringstream str;
+  str << index << " element in Array";
+  parent_ref_id.field_ = str.str();
+
+  (*individualReteiners)[child_addr].references_.insert(parent_ref_id);
+}
+
+
+void XDKSnapshotFiller::SetIndexedAutoIndexReference(HeapGraphEdge::Type type,
+    int parent,
+    HeapEntry* child_entry) {
+}
+
+
+void XDKSnapshotFiller::SetNamedReference(HeapGraphEdge::Type type,
+    int parent,
+    const char* reference_name,
+    HeapEntry* child_entry) {
+  if (child_entry->trace_node_id() < 3) {
+    return;
+  }
+
+  std::map<Address, RefSet>* individualReteiners =
+      allocation_tracker_->GetIndividualReteiners();
+  // get the parent's address, constructor name and form the RefId
+  HashMap::Entry* address_entry = index_to_address_.Lookup(
+      reinterpret_cast<void*>(parent+1), HashInt(parent+1), false);
+  DCHECK(address_entry != NULL);
+  if (!address_entry) {
+    return;
+  }
+  HeapEntry* parent_entry = &(heap_entries_list_[parent]);
+  Address parent_addr = reinterpret_cast<Address>(address_entry->value);
+  RefId parent_ref_id;
+  parent_ref_id.stackId_ = parent_entry->trace_node_id();
+  // TODO(amalyshe): need to get access to classNames_
+  parent_ref_id.classId_ =
+      allocation_tracker_->FindOrInitClassName(parent_addr, 0);
+  parent_ref_id.field_ = reference_name;
+
+  HashMap::Entry* address_entry_child = index_to_address_.Lookup(
+      reinterpret_cast<void*>(child_entry->index()+1),
+      HashInt(child_entry->index()+1), false);
+  DCHECK(address_entry_child != NULL);
+  if (!address_entry_child) {
+    return;
+  }
+  Address child_addr = reinterpret_cast<Address>(address_entry_child->value);
+
+  (*individualReteiners)[child_addr].references_.insert(parent_ref_id);
+}
+
+
+void XDKSnapshotFiller::SetNamedAutoIndexReference(HeapGraphEdge::Type type,
+                                int parent,
+                                HeapEntry* child_entry) {
+}
+
+
+}
+}  // namespace v8::internal

--- a/src/xdk-allocation.h
+++ b/src/xdk-allocation.h
@@ -1,0 +1,189 @@
+// Copyright 2014 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_XDK_ALLOCATION_H_
+#define V8_XDK_ALLOCATION_H_
+
+#include <map>
+#include <string>
+#include "src/base/platform/time.h"
+
+namespace v8 {
+namespace internal {
+
+class HeapObjectsMap;
+class HeapEventXDK;
+class ClassNames;
+class ShadowStack;
+class SymbolsStorage;
+class AggregatedChunks;
+class RuntimeInfo;
+class References;
+struct RefSet;
+struct PostCollectedInfo;
+
+
+class XDKSnapshotFiller: public SnapshotFiller {
+ public:
+  explicit XDKSnapshotFiller(HeapObjectsMap* heap_object_map,
+                             StringsStorage* names,
+                             XDKAllocationTracker* allocation_tracker)
+      : names_(names),
+      allocation_tracker_(allocation_tracker),
+      heap_entries_(HashMap::PointersMatch),
+      index_to_address_(HashMap::PointersMatch) {}
+  virtual ~XDKSnapshotFiller() {}
+
+  HeapEntry* AddEntry(HeapThing ptr, HeapEntriesAllocator* allocator);
+  HeapEntry* FindEntry(HeapThing thing);
+  HeapEntry* FindOrAddEntry(HeapThing ptr, HeapEntriesAllocator* allocator);
+  void SetIndexedReference(HeapGraphEdge::Type type,
+                           int parent,
+                           int index,
+                           HeapEntry* child_entry);
+  void SetIndexedAutoIndexReference(HeapGraphEdge::Type type,
+                                    int parent,
+                                    HeapEntry* child_entry);
+  void SetNamedReference(HeapGraphEdge::Type type,
+                         int parent,
+                         const char* reference_name,
+                         HeapEntry* child_entry);
+  void SetNamedAutoIndexReference(HeapGraphEdge::Type type,
+                                  int parent,
+                                  HeapEntry* child_entry);
+
+ private:
+  StringsStorage* names_;
+  XDKAllocationTracker* allocation_tracker_;
+  HashMap heap_entries_;
+  HashMap index_to_address_;
+
+
+  List<HeapEntry> heap_entries_list_;
+
+  HeapEntry* AddEntry(HeapThing thing,
+                      HeapObject* object,
+                      HeapEntry::Type type,
+                      const char* name);
+
+  static uint32_t Hash(HeapThing thing) {
+    return ComputeIntegerHash(
+        static_cast<uint32_t>(reinterpret_cast<uintptr_t>(thing)),
+        v8::internal::kZeroHashSeed);
+  }
+  static uint32_t HashInt(int key) {
+    return ComputeIntegerHash(key, v8::internal::kZeroHashSeed);
+  }
+};
+
+
+struct InfoToResolve {
+  Address address_;
+  PostCollectedInfo* info_;
+};
+
+
+class XDKAllocationTracker {
+ public:
+  XDKAllocationTracker(HeapProfiler* heap_profiler,
+                       HeapObjectsMap* ids,
+                       StringsStorage* names,
+                       int stackDepth,
+                       bool collectRetention,
+                       bool strict_collection);
+  ~XDKAllocationTracker();
+
+  void OnAlloc(Address addr, int size);
+  void OnMove(Address from, Address to, int size);
+  void CollectFreedObjects(bool bAll = false, bool initPreCollect = false);
+  HeapEventXDK* stopTracking();
+  OutputStream::WriteResult  SendChunk(OutputStream* stream);
+  unsigned GetTraceNodeId(Address address);
+  void clearIndividualReteiners();
+  std::map<Address, RefSet>* GetIndividualReteiners();
+
+  unsigned FindOrInitClassName(Address address, unsigned ts);
+
+ private:
+  static const int RETAINED_DELTA = 1000;
+
+  // external object
+  HeapProfiler* heap_profiler_;
+  HeapObjectsMap* ids_;
+  StringsStorage* names_;
+
+  AggregatedChunks* aggregated_chunks_;
+  RuntimeInfo* runtime_info_;
+  void SerializeChunk(std::string* symbols, std::string* types,
+                      std::string* frames, std::string* chunks,
+                      std::string* retentions, bool final = false);
+
+  unsigned FindClassName(Address address);
+  unsigned InitClassName(Address address, unsigned ts, unsigned size);
+  unsigned InitClassName(Address address, PostCollectedInfo* info);
+
+  SymbolsStorage* symbols_;
+  ShadowStack* collectedStacks_;
+  ClassNames* classNames_;
+
+  unsigned outOfContextFrame_;
+  unsigned AllocatedBeforeCollectionFrame_;
+
+  v8::base::Time baseTime_;
+  unsigned latest_delta_;
+  unsigned int GetTimeDelta();
+
+  int stackDepth_;
+  bool collectRetention_;
+  bool strict_collection_;
+  References* references_;
+  std::map<Address, RefSet> individualReteiners_;
+
+  // here is a loop container which stores the elements not more than
+  // a_treshold_ and when the capacity is reduced we start
+  // 1. resolve the a_current_ object's types
+  // 2. store new allocated object to the a_current_ position
+  // increas a_current_ until a_treshold_. At the moment when it reach the
+  // a_treshold_, a_current_ is assigned to 0
+  // It id required because some types are defined as a analysis of another
+  // object and the allocation sequence might be different. Sometimes dependent
+  // object is allocated first, sometimes parent object is allocated first.
+  // We cannot find type of latest element, all dependent objects must be
+  // created
+  List<InfoToResolve> latest_allocations_;
+  int a_treshold_;
+  int a_current_;
+};
+
+
+class HeapEventXDK {
+ public:
+  HeapEventXDK(unsigned int duration,
+               const std::string& symbols, const std::string& types,
+               const std::string& frames, const std::string& chunks,
+               const std::string& retentions) :
+    symbols_(symbols), types_(types), frames_(frames), chunks_(chunks),
+    duration_(duration), retentions_(retentions) {
+  }
+
+  unsigned int duration() const {return duration_; }
+  const char* symbols() const { return symbols_.c_str(); }
+  const char* types() const { return types_.c_str(); }
+  const char* frames() const { return frames_.c_str(); }
+  const char* chunks() const { return chunks_.c_str(); }
+  const char* retentions()  const { return retentions_.c_str(); }
+
+ private:
+  std::string symbols_;
+  std::string types_;
+  std::string frames_;
+  std::string chunks_;
+  unsigned int duration_;
+  std::string retentions_;
+  DISALLOW_COPY_AND_ASSIGN(HeapEventXDK);
+};
+
+} }  // namespace v8::internal
+
+#endif  // V8_XDK_ALLOCATION_H_

--- a/src/xdk-utils.cc
+++ b/src/xdk-utils.cc
@@ -1,0 +1,671 @@
+// Copyright 2014 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/v8.h"
+
+#include "src/frames-inl.h"
+#include "src/xdk-utils.h"
+
+namespace v8 {
+namespace internal {
+
+static bool AddressesMatch(void* key1, void* key2) {
+  return key1 == key2;
+}
+
+
+static uint32_t CharAddressHash(char* addr) {
+  return ComputeIntegerHash(static_cast<uint32_t>(
+      reinterpret_cast<uintptr_t>(addr)),
+      v8::internal::kZeroHashSeed);
+}
+
+
+static uint32_t AddressHash(Address addr) {
+  return ComputeIntegerHash(static_cast<uint32_t>(
+      reinterpret_cast<uintptr_t>(addr)),
+      v8::internal::kZeroHashSeed);
+}
+
+
+ClassNames::ClassNames(StringsStorage* names, Heap* heap)
+    : counter_(0),
+    char_to_idx_(AddressesMatch),
+    names_(names),
+    heap_(heap) {
+  id_native_bind_ = registerName(names->GetCopy("native_bind"));
+  id_conc_string_ = registerName(names->GetCopy("(concatenated string)"));
+  id_sliced_string_ = registerName(names->GetCopy("(sliced string)"));
+  id_string_ = registerName(names->GetCopy("String"));
+  id_symbol_ = registerName(names->GetCopy("(symbol)"));
+  id_code_ = registerName(names->GetCopy("(compiled code)"));
+  id_system_ncontext_ =
+      registerName(names->GetCopy("(system / NativeContext)"));
+  id_system_context_ = registerName(names->GetCopy("(system / Context)"));
+  id_array_ = registerName(names->GetCopy("(array)"));
+  id_number_ = registerName(names->GetCopy("(number)"));
+  id_system_ = registerName(names->GetCopy("(system)"));
+  id_shared_fi_ = registerName(names->GetCopy("(shared function info)"));
+  id_script_ = registerName(names->GetCopy("(script)"));
+  id_regexp_ = registerName(names->GetCopy("RegExp"));
+  id_function_bindings_ =
+      registerName(names->GetCopy("(function bindings)"));
+  id_function_literals_ = registerName(names->GetCopy("(function literals)"));
+  id_objects_properties_ = registerName(names->GetCopy("(object properties)"));
+  id_objects_elements_ = registerName(names->GetCopy("(object elements)"));
+  id_shared_function_info_ =
+      registerName(names->GetCopy("(shared function info)"));
+  id_context_ = registerName(names->GetCopy("(context)"));
+  id_code_relocation_info_ =
+      registerName(names->GetCopy("(code relocation info)"));
+  id_code_deopt_data_ = registerName(names->GetCopy("(code deopt data)"));
+}
+
+
+unsigned ClassNames::registerName(const char* name) {
+  // since const char is retained outside and cannot be moved, we rely on this
+  // and just compare the pointers. It should be enough for the strings from the
+  // only one StringStorage
+  if (!name) {
+    return -2;
+  }
+
+  unsigned counter;
+  HashMap::Entry* entry = char_to_idx_.Lookup(const_cast<char*>(name),
+      CharAddressHash(const_cast<char*>(name)),
+      true);
+  if (entry->value == NULL) {
+    counter = ++counter_;
+    entry->value = reinterpret_cast<void*>(counter);
+  } else {
+    counter = static_cast<unsigned>(reinterpret_cast<uintptr_t>(entry->value));
+  }
+  return counter;
+}
+
+
+std::string ClassNames::SerializeChunk() {
+  std::stringstream serialized;
+  for (HashMap::Entry* p = char_to_idx_.Start(); p != NULL;
+      p = char_to_idx_.Next(p)) {
+    serialized << static_cast<unsigned>(
+        reinterpret_cast<uintptr_t>(p->value)) << "," <<
+        reinterpret_cast<char*>(p->key) << std::endl;
+  }
+
+  return serialized.str();
+}
+
+
+bool ClassNames::IsEssentialObject(Object* object) {
+  return object->IsHeapObject()
+      && !object->IsOddball()
+      && object != heap_->empty_byte_array()
+      && object != heap_->empty_fixed_array()
+      && object != heap_->empty_descriptor_array()
+      && object != heap_->fixed_array_map()
+      && object != heap_->cell_map()
+      && object != heap_->global_property_cell_map()
+      && object != heap_->shared_function_info_map()
+      && object != heap_->free_space_map()
+      && object != heap_->one_pointer_filler_map()
+      && object != heap_->two_pointer_filler_map();
+}
+
+
+void ClassNames::registerNameForDependent(HeapObject* object,
+                                          RuntimeInfo* runtime_info,
+                                          unsigned id) {
+  if (object && IsEssentialObject(object)) {
+    PostCollectedInfo* info =
+      runtime_info->FindPostCollectedInfo(object->address());
+    // TODO(amalyshe) here we are loosing some information because
+    // *some* of the objects are allocated without notification of explicit
+    // allocation and no XDKAllocationTracker::OnAlloc will be called for them.
+    // But these objects exist in the heap and can be achieved if we iterate
+    // through the heap. We cannot add here them explicitly because if
+    // XDKAllocationTracker::OnAlloc is called for this address, it will remove
+    // all useful information about type and even report wrong data because
+    // during removal these objects will be added to statistic and will be
+    // counted twice
+    if (info) {
+      info->className_ = id;
+    }
+  }
+}
+
+unsigned ClassNames::GetConstructorName(Address address,
+                                           RuntimeInfo* runtime_info) {
+  unsigned id = (unsigned)-2;
+  HeapObject* heap_object = HeapObject::FromAddress(address);
+
+  // support of all type, if some are built-in, we add hard-coded values
+  if (heap_object->IsJSObject()) {
+    JSObject* object = JSObject::cast(heap_object);
+    if (object->IsJSFunction()) {
+      Heap* heap = object->GetHeap();
+      const char* name = names_->GetName(String::cast(heap->closure_string()));
+      id = registerName(name);
+      JSFunction* js_fun = JSFunction::cast(object);
+      SharedFunctionInfo* shared_info = js_fun->shared();
+      bool bound = shared_info->bound();
+      HeapObject* obj = js_fun->literals_or_bindings();
+      unsigned lob_id = bound ? id_function_bindings_ : id_function_literals_;
+      registerNameForDependent(obj, runtime_info, lob_id);
+      registerNameForDependent(shared_info, runtime_info,
+                               id_shared_function_info_);
+      registerNameForDependent(js_fun->context(), runtime_info,
+                               id_context_);
+    } else {
+      const char* name = names_->GetName(object->constructor_name());
+      id = registerName(name);
+    }
+    HeapObject* prop = reinterpret_cast<HeapObject*>(object->properties());
+    registerNameForDependent(prop, runtime_info, id_objects_properties_);
+    HeapObject* elements = reinterpret_cast<HeapObject*>(object->elements());
+    registerNameForDependent(elements, runtime_info, id_objects_elements_);
+  } else if (heap_object->IsJSFunction()) {
+    JSFunction* func = JSFunction::cast(heap_object);
+    SharedFunctionInfo* shared = func->shared();
+    id = shared->bound() ? id_native_bind_ :
+        registerName(names_->GetName(String::cast(shared->name())));
+  } else if (heap_object->IsJSRegExp()) {
+      id = id_regexp_;
+  } else if (heap_object->IsString()) {
+    String* string = String::cast(heap_object);
+    if (string->IsConsString())
+      id = id_conc_string_;
+    else if (string->IsSlicedString())
+      id = id_sliced_string_;
+    else
+      id = id_string_;
+  } else if (heap_object->IsSymbol()) {
+    id = id_symbol_;
+  } else if (heap_object->IsCode()) {
+    Code* code = Code::cast(heap_object);
+    registerNameForDependent(code->relocation_info(), runtime_info,
+                               id_code_relocation_info_);
+    registerNameForDependent(code->deoptimization_data(), runtime_info,
+                               id_code_deopt_data_);
+    id = id_code_;
+  } else if (heap_object->IsSharedFunctionInfo()) {
+      id = id_shared_fi_;
+  } else if (heap_object->IsScript()) {
+    id = id_script_;
+  } else if (heap_object->IsNativeContext()) {
+    id = id_system_ncontext_;
+  } else if (heap_object->IsContext()) {
+    id = id_system_context_;
+  } else if (heap_object->IsFixedArray() ||
+             heap_object->IsFixedDoubleArray() ||
+             heap_object->IsByteArray() ||
+             heap_object->IsExternalArray() ) {
+    id = id_array_;
+  } else if (heap_object->IsHeapNumber()) {
+    id = id_number_;
+  } else {
+    id = id_system_;
+  }
+
+  return id;
+}
+
+
+// -----------------------------------------------------------------------------
+ShadowStack::ShadowStack() {
+  last_index_ = 1;
+  serializedCounter_ = last_index_;
+  root_.index_ = 0;
+  root_.parent_ = NULL;
+  root_.callsite_ = 0;
+}
+
+
+ShadowStack::~ShadowStack() {
+  // erasing all objects from the current container
+  std::map<unsigned, CallTree*>::iterator eit = allNodes_.begin();
+  while (eit != allNodes_.end()) {
+    delete eit->second;
+    eit++;
+  }
+}
+
+
+unsigned ShadowStack::registerStack(const List<unsigned>& shadow_stack_) {
+    // look for the latest node
+    CallTree* pNode = &root_;
+    // go over all entries and add them to the tree if they are not in the map
+    int i, j;
+    for (i = shadow_stack_.length()-1; i != -1; i--) {
+      std::map<unsigned, CallTree*>::iterator it =
+          pNode->children_.find(shadow_stack_[i]);
+      if (it == pNode->children_.end())
+          break;
+      pNode = it->second;
+    }
+    // verification if we need to add something or not
+    for (j = i; j != -1; j--) {
+      CallTree* pNodeTmp = new CallTree;
+      pNodeTmp->index_ = last_index_++;
+      pNodeTmp->parent_ = pNode;
+      pNodeTmp->callsite_ = shadow_stack_[j];
+      pNode->children_[shadow_stack_[j]] = pNodeTmp;
+      allNodes_[pNodeTmp->index_] = pNodeTmp;
+      pNode = pNodeTmp;
+    }
+    return pNode->index_;
+}
+
+
+std::string ShadowStack::SerializeChunk() {
+  std::stringstream str;
+  std::map<unsigned, CallTree*>::iterator it =
+      allNodes_.find(serializedCounter_);
+  while (it!= allNodes_.end()) {
+    str << it->first << "," << it->second->callsite_ << "," <<
+        it->second->parent_->index_ << std::endl;
+    it++;
+  }
+
+  serializedCounter_ = last_index_;
+  return str.str();
+}
+
+
+// -----------------------------------------------------------------------------
+static bool SymInfoMatch(void* key1, void* key2) {
+  SymInfoKey* key_c1 = reinterpret_cast<SymInfoKey*>(key1);
+  SymInfoKey* key_c2 = reinterpret_cast<SymInfoKey*>(key2);
+  return *key_c1 == *key_c2;
+}
+
+
+static uint32_t SymInfoHash(const SymInfoKey& key) {
+  uint32_t hash = 0;
+  // take the low 16 bits of function_id_
+  hash |= (key.function_id_ & 0xffff);
+  // take the low 8 bits of line_ and column_ and init highest bits
+  hash |= ((key.line_ & 0xff) << 16);
+  hash |= ((key.column_ & 0xff) << 14);
+
+  return hash;
+}
+
+
+struct SymbolCached {
+  unsigned int symbol_id_;
+  uintptr_t function_;
+};
+
+
+SymbolsStorage::SymbolsStorage(Heap* heap, StringsStorage* names) :
+  symbols_(SymInfoMatch),
+  curSym_(1),
+  sym_info_hash_(AddressesMatch),
+  heap_(heap),
+  names_(names) {
+  reserved_key_ = new SymInfoKey();
+}
+
+
+SymbolsStorage::~SymbolsStorage() {
+  // go over map and delete all keys and values
+  for (HashMap::Entry* p = symbols_.Start(); p != NULL; p = symbols_.Next(p)) {
+    delete reinterpret_cast<SymInfoValue*>(p->value);
+    delete reinterpret_cast<SymInfoKey*>(p->key);
+  }
+  delete reserved_key_;
+}
+
+
+unsigned SymbolsStorage::registerSymInfo(size_t functionId,
+                                         std::string functionName,
+                                         std::string sourceName,
+                                         unsigned line,
+                                         unsigned column) {
+  if (sourceName.empty()) {
+    sourceName = "unknown";
+  }
+
+  reserved_key_->function_id_ = functionId;
+  reserved_key_->line_ = line;
+  reserved_key_->column_ = column;
+
+  HashMap::Entry* entry = symbols_.Lookup(reserved_key_,
+                                          SymInfoHash(*reserved_key_), true);
+  if (entry->value) {
+    return reinterpret_cast<SymInfoValue*>(entry->value)->symId_;
+  }
+
+  // else initialize by new one
+  SymInfoValue* value = new SymInfoValue;
+  value->symId_ = curSym_++;
+  value->funcName_ = functionName;
+  value->sourceFile_ = sourceName;
+  entry->value = value;
+
+  // compensation for registered one
+  reserved_key_ = new SymInfoKey();
+
+  return value->symId_;
+}
+
+
+std::string SymbolsStorage::SerializeChunk() {
+  std::stringstream serialized;
+  for (HashMap::Entry* p = symbols_.Start(); p != NULL; p = symbols_.Next(p)) {
+    SymInfoValue* v = reinterpret_cast<SymInfoValue*>(p->value);
+    SymInfoKey* k = reinterpret_cast<SymInfoKey*>(p->key);
+    serialized << v->symId_ << "," << k->function_id_ << "," <<
+        v->funcName_ << "," << v->sourceFile_ << "," <<
+        k->line_ << "," << k->column_ << std::endl;
+  }
+
+  return serialized.str();
+}
+
+
+unsigned SymbolsStorage::FindOrRegisterFrame(JavaScriptFrame* frame) {
+  SharedFunctionInfo *shared = frame->function()->shared();
+  DCHECK(shared);
+  Isolate *isolate = heap_->isolate();
+
+  Address pc = frame->pc();
+  unsigned int symbolId = 0;
+
+  // We don't rely on the address only. Since this is JIT based language,
+  // the address might be occupied by other function
+  // thus we are verifying if the same function takes this place
+  // before we take symbol info from the cache
+  HashMap::Entry* sym_entry = sym_info_hash_.Lookup(
+          reinterpret_cast<void*>(pc), AddressHash(pc), true);
+  if (sym_entry->value == NULL ||
+      (reinterpret_cast<SymbolCached*>(sym_entry->value)->function_ !=
+        reinterpret_cast<uintptr_t>(frame->function()))) {
+    if (sym_entry->value) {
+      delete reinterpret_cast<SymbolCached*>(sym_entry->value);
+    }
+
+    const char *s = names_->GetFunctionName(shared->DebugName());
+    // trying to get the source name and line#
+    Code *code = Code::cast(isolate->FindCodeObject(pc));
+    if (code) {
+      int source_pos = code->SourcePosition(pc);
+      Object *maybe_script = shared->script();
+      if (maybe_script && maybe_script->IsScript()) {
+        Handle<Script> script(Script::cast(maybe_script));
+        if (!script.is_null()) {
+          int line = script->GetLineNumber(source_pos) + 1;
+          // TODO(amalyshe): check if this can be used:
+          // int line = GetScriptLineNumberSafe(script, source_pos) + 1;
+          // TODO(amalyshe): add column number getting
+          int column = 0;  // GetScriptColumnNumber(script, source_pos);
+          Object *script_name_raw = script->name();
+          if (script_name_raw->IsString()) {
+            String *script_name = String::cast(script->name());
+            SmartArrayPointer<char> c_script_name =
+              script_name->ToCString(DISALLOW_NULLS, ROBUST_STRING_TRAVERSAL);
+            symbolId = registerSymInfo((size_t)frame->function(), s,
+                                       c_script_name.get(), line, column);
+          }
+        }
+      }
+    }
+    if (symbolId == 0) {
+      symbolId = registerSymInfo((size_t)frame->function(), s, "", 0, 0);
+    }
+
+    SymbolCached* symCached = new SymbolCached;
+    symCached->function_ = reinterpret_cast<uintptr_t>(frame->function());
+    symCached->symbol_id_ = symbolId;
+    sym_entry->value = symCached;
+  } else {
+    symbolId = reinterpret_cast<SymbolCached*>(sym_entry->value)->symbol_id_;
+  }
+  return symbolId;
+}
+
+
+// -----------------------------------------------------------------------------
+RuntimeInfo::RuntimeInfo(AggregatedChunks* aggregated_chunks):
+  working_set_hash_(AddressesMatch),
+  aggregated_chunks_(aggregated_chunks),
+  AllocatedBeforeCollectionFrame_(0) {
+}
+
+
+PostCollectedInfo* RuntimeInfo::FindPostCollectedInfo(Address addr) {
+  HashMap::Entry* entry = working_set_hash_.Lookup(
+          reinterpret_cast<void*>(addr), AddressHash(addr), false);
+  if (entry && entry->value) {
+    PostCollectedInfo* info =
+        reinterpret_cast<PostCollectedInfo*>(entry->value);
+    return info;
+  }
+  return NULL;
+}
+
+
+PostCollectedInfo* RuntimeInfo::AddPostCollectedInfo(Address addr,
+                                                    unsigned time_delta,
+                                                    PostCollectedInfo* info) {
+  PostCollectedInfo* info_new = NULL;
+  if (!info) {
+    info_new = new PostCollectedInfo;
+  } else {
+    info_new = info;
+  }
+
+  HashMap::Entry* entry = working_set_hash_.Lookup(
+          reinterpret_cast<void*>(addr), AddressHash(addr), true);
+  DCHECK(entry);
+  if (entry->value != NULL) {
+    // compensation of the wrong deallocation place
+    // we were not able to work the GC epilogue callback because GC is not
+    // iteratable in the prologue
+    // thus we need to mark the object as freed
+    PostCollectedInfo* info_old =
+        static_cast<PostCollectedInfo*>(entry->value);
+    aggregated_chunks_->addObjectToAggregated(info_old, time_delta);
+    delete info_old;
+  }
+
+  entry->value = info_new;
+  return info_new;
+}
+
+
+PostCollectedInfo* RuntimeInfo::AddPreCollectionInfo(Address addr,
+                                                     unsigned size) {
+  PostCollectedInfo* info = AddPostCollectedInfo(addr);
+  info->size_ = size;
+  info->timeStamp_ = 0;
+  info->stackId_ = AllocatedBeforeCollectionFrame_;
+  info->className_ = (unsigned)-1;
+  return info;
+}
+
+
+void RuntimeInfo::RemoveInfo(Address addr) {
+  working_set_hash_.Remove(reinterpret_cast<void*>(addr), AddressHash(addr));
+}
+
+
+void RuntimeInfo::InitABCFrame(unsigned abc_frame) {
+  AllocatedBeforeCollectionFrame_ = abc_frame;
+}
+
+
+void RuntimeInfo::CollectGarbaged(unsigned ts) {
+  // iteration over the working_set_hash_
+  for (HashMap::Entry* p = working_set_hash_.Start(); p != NULL;
+      p = working_set_hash_.Next(p)) {
+    if (p->value) {
+      PostCollectedInfo* info = static_cast<PostCollectedInfo*>(p->value);
+      if (info->dirty_ == false) {
+        // need to care of allocated during collection.
+        // if timeStamp_ == 0 this object was allocated before collection
+        // and we don't care of it
+        aggregated_chunks_->addObjectToAggregated(info, ts);
+        delete info;
+        p->value = NULL;
+      } else {
+        info->dirty_ = false;
+      }
+    }
+  }
+}
+
+
+//------------------------------------------------------------------------------
+static bool AggregatedMatch(void* key1, void* key2) {
+  // cast to the AggregatedKey
+  AggregatedKey* key_c1 = reinterpret_cast<AggregatedKey*>(key1);
+  AggregatedKey* key_c2 = reinterpret_cast<AggregatedKey*>(key2);
+  return *key_c1 == *key_c2;
+}
+
+
+static uint32_t AggregatedHash(const AggregatedKey& key) {
+  uint32_t hash = 0;
+  // take the low 8 bits of stackId_
+  hash |= (key.stackId_ & 0xff);
+  // take the low 8 bits of classId_ and init hash from 8th to 15th bits
+  hash |= ((key.classId_ & 0xff) << 8);
+  // since times are well graduated it's no sense take the lowest 8 bit
+  // instead this we will move to 3 bits and only then take 8 bits
+  hash |= (((key.tsBegin_ >> 3) & 0xff) << 16);
+  hash |= (((key.tsBegin_ >> 3) & 0xff) << 24);
+  return hash;
+}
+
+
+AggregatedChunks::AggregatedChunks() :
+  aggregated_map_(AggregatedMatch),
+  bucketSize_(500) {
+  reserved_key_ = new AggregatedKey();
+}
+
+
+AggregatedChunks::~AggregatedChunks() {
+  delete reserved_key_;
+}
+
+
+void AggregatedChunks::addObjectToAggregated(PostCollectedInfo* info,
+                                                        unsigned td) {
+  reserved_key_->stackId_ = info->stackId_;
+  reserved_key_->classId_ = info->className_;
+  // get the bucket for the first time
+  reserved_key_->tsBegin_ = info->timeStamp_ - (info->timeStamp_ % bucketSize_);
+  reserved_key_->tsEnd_ = td - (td % bucketSize_);
+
+  HashMap::Entry* aggregated_entry = aggregated_map_.Lookup(reserved_key_,
+                                                AggregatedHash(*reserved_key_),
+                                                true);
+  if (aggregated_entry->value) {
+    // no need to store the latest record in the aggregated_keys_list_
+    AggregatedValue* value =
+                reinterpret_cast<AggregatedValue*>(aggregated_entry->value);
+    value->objects_++;
+    value->size_ += info->size_;
+  } else {
+    reserved_key_ = new AggregatedKey;
+    AggregatedValue* value = new AggregatedValue;
+    value->objects_ = 1;
+    value->size_ = info->size_;
+    aggregated_entry->value = value;
+  }
+}
+
+
+std::string AggregatedChunks::SerializeChunk() {
+  std::stringstream schunks;
+  for (HashMap::Entry* p = aggregated_map_.Start(); p != NULL;
+      p = aggregated_map_.Next(p)) {
+    if (p->key && p->value) {
+      AggregatedKey* key = reinterpret_cast<AggregatedKey*>(p->key);
+      AggregatedValue* value = reinterpret_cast<AggregatedValue*>(p->value);
+      schunks <<
+        key->tsBegin_ << "," << key->tsEnd_ << "," <<
+        key->stackId_ << "," << key->classId_ << "," <<
+        value->size_ << "," << value->objects_ << std::endl;
+      delete key;
+      delete value;
+    }
+  }
+
+  aggregated_map_.Clear();
+
+  return schunks.str();
+}
+
+
+// -----------------------------------------------------------------------------
+void References::addReference(const RefId& parent, const RefSet& refSet,
+                               int parentTime) {
+  // looking for the parent in the refMap_
+  PARENTREFMAP::iterator cit = refMap_.find(parent);
+  if (cit != refMap_.end()) {
+    REFERENCESETS& sets = cit->second;
+    REFERENCESETS::iterator it = sets.find(refSet);
+    if (it != sets.end()) {
+      // look for the time
+      TIMETOCOUNT::iterator cittc = it->second.find(parentTime);
+      if (cittc != it->second.end()) {
+        cittc->second++;
+      } else {
+        it->second[parentTime] = 1;
+      }
+    } else {
+      TIMETOCOUNT tc;
+      tc[parentTime] = 1;
+      sets[refSet] = tc;
+    }
+  } else {
+    // adding new parent, new sets
+    REFERENCESETS sets;
+    TIMETOCOUNT tc;
+    tc[parentTime] = 1;
+    sets[refSet] = tc;
+    refMap_[parent] = sets;
+  }
+}
+
+
+void References::clear() {
+  refMap_.clear();
+}
+
+
+std::string References::serialize() const {
+  std::stringstream str;
+  PARENTREFMAP::const_iterator citrefs = refMap_.begin();
+  while (citrefs != refMap_.end()) {
+    REFERENCESETS::const_iterator citsets = citrefs->second.begin();
+    while (citsets != citrefs->second.end()) {
+      str << citrefs->first.stackId_ << "," << citrefs->first.classId_;
+      // output of length, and content of TIMETOCOUNT
+      str << "," << citsets->second.size();
+      TIMETOCOUNT::const_iterator cittc = citsets->second.begin();
+      while (cittc != citsets->second.end()) {
+        str << "," << cittc->first << "," << cittc->second;
+        cittc++;
+      }
+      REFERENCESET::const_iterator citset = citsets->first.references_.begin();
+      while (citset != citsets->first.references_.end()) {
+        str << "," << citset->stackId_ << "," << citset->classId_<< "," <<
+          citset->field_;
+        citset++;
+      }
+      str << std::endl;
+      citsets++;
+    }
+    citrefs++;
+  }
+  return str.str();
+}
+
+
+} }  // namespace v8::internal

--- a/src/xdk-utils.h
+++ b/src/xdk-utils.h
@@ -1,0 +1,279 @@
+// Copyright 2014 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef __xdk_utils_h__
+#define __xdk_utils_h__
+
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include "src/hashmap.h"
+
+namespace v8 {
+namespace internal {
+
+class AggregatedChunks;
+class StringsStorage;
+class JavaScriptFrame;
+class RuntimeInfo;
+
+// --- ClassNames
+class ClassNames {
+ public:
+  explicit ClassNames(StringsStorage* names, Heap* heap);
+
+  unsigned registerName(const char* className);
+  std::string SerializeChunk();
+  bool IsEssentialObject(Object* object);
+  void registerNameForDependent(HeapObject* object,
+                                RuntimeInfo* runtime_info,
+                                unsigned id);
+  unsigned GetConstructorName(Address address, RuntimeInfo* runtime_info);
+
+
+ private:
+  unsigned counter_;
+  HashMap char_to_idx_;
+  StringsStorage* names_;
+  Heap* heap_;
+
+  unsigned id_native_bind_;
+  unsigned id_conc_string_;
+  unsigned id_sliced_string_;
+  unsigned id_string_;
+  unsigned id_symbol_;
+  unsigned id_code_;
+  unsigned id_system_ncontext_;
+  unsigned id_system_context_;
+  unsigned id_array_;
+  unsigned id_number_;
+  unsigned id_system_;
+  unsigned id_shared_fi_;
+  unsigned id_script_;
+  unsigned id_regexp_;
+  unsigned id_function_bindings_;
+  unsigned id_function_literals_;
+  unsigned id_objects_properties_;
+  unsigned id_objects_elements_;
+  unsigned id_shared_function_info_;
+  unsigned id_context_;
+  unsigned id_code_relocation_info_;
+  unsigned id_code_deopt_data_;
+};
+
+
+// --- ShadowStack
+class CallTree {
+ public:
+  // For quick search we use below member. it is not reasnable to use here
+  // map because it occupies a lot of space even in empty state and such nodes
+  // will be many. In opposite to map, std::map uses binary tree search and
+  // don't store buffer, but allocates it dinamically
+  std::map<unsigned, CallTree*> children_;
+
+  // This is _not_ the same as index in the children_. This index is
+  // incremental value from list of all nodes, but the key in the children_ is
+  // callsite
+  unsigned index_;
+  CallTree* parent_;
+  // the only one field which characterize the call point
+  unsigned callsite_;
+};
+
+
+class ShadowStack {
+  CallTree root_;
+
+  // unsigned here is ok, size_t is not required because even 10 millions
+  // objects in this class will lead to the significant memory consumption
+  unsigned last_index_;
+
+  // TODO(amalyshe): rewrite using List, storing nodes and use index in the list
+  // instead pointer to CallTree in the children_
+  std::map<unsigned, CallTree*> allNodes_;
+  unsigned serializedCounter_;
+ public:
+  ShadowStack();
+  ~ShadowStack();
+  // Returns unique stack id. This method can work with incremental stacks when
+  // we have old stack id, new tail and number of functions that we need to
+  // unroll.
+  unsigned registerStack(const List<unsigned>& shadow_stack_);
+  std::string SerializeChunk();
+};
+
+
+// --- SymbolsStorage
+struct SymInfoKey {
+  size_t function_id_;
+  unsigned line_;
+  unsigned column_;
+};
+
+bool inline operator == (const SymInfoKey& key1, const SymInfoKey& key2) {
+  return key1.function_id_ == key2.function_id_ &&
+    key1.line_ == key2.line_ &&
+    key1.column_ == key2.column_;
+}
+
+
+struct SymInfoValue {
+  unsigned symId_;
+  std::string funcName_;
+  std::string sourceFile_;
+};
+
+
+class SymbolsStorage {
+ public:
+  unsigned registerSymInfo(size_t functionId,
+                               std::string functionName,
+                               std::string sourceName, unsigned line,
+                               unsigned column);
+  unsigned FindOrRegisterFrame(JavaScriptFrame* frame);
+  SymbolsStorage(Heap* heap, StringsStorage* names);
+  ~SymbolsStorage();
+  std::string SerializeChunk();
+
+ private:
+  HashMap symbols_;
+  unsigned curSym_;
+  // fast living storage which duplicate info but is cleaned regularly
+  SymInfoKey* reserved_key_;
+  HashMap sym_info_hash_;
+  Heap* heap_;
+  StringsStorage* names_;
+};
+
+
+struct PostCollectedInfo {
+  int size_;
+  int timeStamp_;
+  int stackId_;
+  unsigned className_;
+  bool dirty_;
+};
+
+
+class RuntimeInfo {
+ public:
+  explicit RuntimeInfo(AggregatedChunks* aggregated_chunks);
+  PostCollectedInfo* FindPostCollectedInfo(Address addr);
+  PostCollectedInfo* AddPostCollectedInfo(Address addr,
+                                          unsigned time_delta = 0,
+                                          PostCollectedInfo* info = NULL);
+  PostCollectedInfo* AddPreCollectionInfo(Address addr, unsigned size);
+  void RemoveInfo(Address addr);
+  void InitABCFrame(unsigned abc_frame);
+  void CollectGarbaged(unsigned ts);
+
+ private:
+  HashMap working_set_hash_;
+  AggregatedChunks* aggregated_chunks_;
+  unsigned AllocatedBeforeCollectionFrame_;
+};
+
+
+struct AggregatedKey {
+  int stackId_;
+  // do we need class here? is not it defined by the stack id?
+  unsigned classId_;
+  unsigned tsBegin_;
+  unsigned tsEnd_;
+};
+
+bool inline operator == (const AggregatedKey& key1, const AggregatedKey& key2) {
+  return key1.stackId_ == key2.stackId_ &&
+    key1.classId_ == key2.classId_ &&
+    key1.tsBegin_ == key2.tsBegin_ &&
+    key1.tsEnd_ == key2.tsEnd_;
+}
+
+
+struct AggregatedValue {
+  unsigned size_;
+  unsigned objects_;
+};
+
+
+class AggregatedChunks {
+ public:
+  AggregatedChunks();
+  ~AggregatedChunks();
+  void addObjectToAggregated(PostCollectedInfo* info, unsigned td);
+  std::string SerializeChunk();
+
+ private:
+  HashMap aggregated_map_;
+  int bucketSize_;
+  AggregatedKey* reserved_key_;
+};
+
+
+struct RefId {
+  int stackId_;
+  int classId_;
+  std::string field_;
+};
+
+inline bool operator < (const RefId& first, const RefId& second ) {
+  if (first.stackId_ < second.stackId_ )
+    return true;
+  else if (first.stackId_ > second.stackId_ )
+    return false;
+  if (first.classId_ < second.classId_ )
+    return true;
+  if (first.classId_ > second.classId_ )
+    return false;
+  if (first.field_.compare(second.field_) < 0 )
+    return true;
+
+  return false;
+}
+
+typedef std::set<RefId> REFERENCESET;
+
+
+struct RefSet {
+  REFERENCESET references_;
+};
+
+inline bool operator < (const RefSet& first, const RefSet& second) {
+  // compare the sizes first of all
+  if (first.references_.size() != second.references_.size() )
+    return first.references_.size() < second.references_.size();
+  // iterating by the first
+  REFERENCESET::const_iterator cit1 = first.references_.begin();
+  REFERENCESET::const_iterator cit2 = second.references_.begin();
+  while (cit1 != first.references_.end()) {
+    if (*cit1 < *cit2 )
+      return true;
+    if (*cit2 < *cit1 )
+      return false;
+    cit1++;
+    cit2++;
+  }
+  return false;
+}
+typedef std::map<unsigned int, int> TIMETOCOUNT;
+typedef std::map<RefSet, TIMETOCOUNT> REFERENCESETS;
+typedef std::map<RefId, REFERENCESETS> PARENTREFMAP;
+
+
+class References {
+ public:
+  void addReference(const RefId& parent,
+                    const RefSet& refSet,
+                    int parentTime);
+  void clear();
+  std::string serialize() const;
+
+ private:
+  PARENTREFMAP refMap_;
+};
+
+
+} }  // namespace v8::internal
+#endif  // __xdk_utils_h__

--- a/test/cctest/test-heap-profiler.cc
+++ b/test/cctest/test-heap-profiler.cc
@@ -38,6 +38,7 @@
 #include "src/heap-profiler.h"
 #include "src/snapshot.h"
 #include "src/utils-inl.h"
+#include "src/xdk-utils.h"
 #include "test/cctest/cctest.h"
 
 using i::AllocationTraceNode;
@@ -2835,4 +2836,376 @@ TEST(AddressToTraceMap) {
   map.Clear();
   CHECK_EQ(0u, map.size());
   CHECK_EQ(0u, map.GetTraceNodeId(ToAddress(0x400)));
+}
+
+struct TestObjectInfo {
+  std::vector<std::string> bu_call_stack_;
+  std::string type_;
+  unsigned number_of_objects_;
+};
+
+struct TestFrameInfo {
+  unsigned frame_id_;
+  unsigned callsite_;
+  unsigned parent_;
+};
+
+struct Chunk {
+  unsigned time_begin_;
+  unsigned time_end_;
+  unsigned frame_id_;
+  unsigned type_id_;
+  unsigned size_;
+  unsigned number_of_objects_;
+};
+
+class XDKHPOutputChecker {
+ public:
+  // If info.number_of_objects_ is not eq 0, then it participates in the search
+  // and we look for the record by 3 parameters. In other case we look for the
+  // chunk by call stack and type id only
+  bool checkObjectsExists(const TestObjectInfo& info, std::string chunk) {
+    std::vector<Chunk> chunks = parseChunk(chunk);
+    // look for the frame id, which correspond to the passed stack
+    // get the type id:
+    std::vector<unsigned> frames = findFrame(info.bu_call_stack_);
+    unsigned type_id = types_[info.type_];
+    for (size_t i = 0; i < chunks.size(); i++) {
+      for (size_t j = 0; j < frames.size(); j++) {
+        if (chunks[i].frame_id_ == frames[j] && chunks[i].type_id_ == type_id &&
+            (info.number_of_objects_ ? chunks[i].number_of_objects_ ==
+            info.number_of_objects_ : true)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+  void parse(const char* symbols, const char* frames, const char* types) {
+    std::string symbols_std_ = symbols;
+    std::string frames_std_ = frames;
+    std::string types_std_ = types;
+    {
+      // parse symbols, don't care of line and column
+      size_t s1_pos = 0, s2_pos = 0;
+      int sym_id;
+      std::string function_name;
+      while (s2_pos != symbols_std_.npos) {
+        // look for the \n symbol
+        // format: symId, funcId, funcName, line, column
+        s2_pos = symbols_std_.find("\n", s1_pos);
+        if (s2_pos != symbols_std_.npos) {
+          int sym_id_e = symbols_std_.find(",", s1_pos);
+          std::string sym_id_s = symbols_std_.substr(s1_pos, sym_id_e - s1_pos);
+          sym_id = atoi(sym_id_s.c_str());
+          int func_id_e = symbols_std_.find(",", sym_id_e + 1);
+          int finc_name_e = symbols_std_.find(",", func_id_e + 1);
+          function_name = symbols_std_.substr(func_id_e + 1, finc_name_e -
+              func_id_e - 1);
+          symbols_[function_name] = sym_id;
+          s1_pos = s2_pos + 1;
+        }
+      }
+    }
+    {
+      // parse types
+      size_t s1_pos = 0, s2_pos = 0;
+      unsigned type_id;
+      std::string type_name;
+      while (s2_pos != types_std_.npos) {
+        // look for the \n symbol
+        // format: typeId, typeName
+        s2_pos = types_std_.find("\n", s1_pos);
+        if (s2_pos != types_std_.npos) {
+          int type_id_e = types_std_.find(",", s1_pos);
+          std::string sym_id_s = types_std_.substr(s1_pos, type_id_e - s1_pos);
+          type_id = atoi(sym_id_s.c_str());
+          type_name = types_std_.substr(type_id_e + 1, s2_pos - type_id_e - 1);
+
+          types_[type_name] = type_id;
+          s1_pos = s2_pos + 1;
+        }
+      }
+    }
+    {
+      // parse frames
+      size_t s1_pos = 0, s2_pos = 0;
+      int frame_id, symbol_id, parent_id;
+      while (s2_pos != frames_std_.npos) {
+        // look for the \n symbol
+        // format: frameId, symbolId, parentId
+        s2_pos = frames_std_.find("\n", s1_pos);
+        if (s2_pos != frames_std_.npos) {
+          int frame_id_e = frames_std_.find(",", s1_pos);
+          std::string frame_id_s = frames_std_.substr(s1_pos,
+                                                      frame_id_e - s1_pos);
+          frame_id = atoi(frame_id_s.c_str());
+
+          int symb_id_e = frames_std_.find(",", frame_id_e + 1);
+          std::string symb_id_s = frames_std_.substr(frame_id_e + 1,
+                                                    symb_id_e - frame_id_e - 1);
+          symbol_id = atoi(symb_id_s.c_str());
+
+          int parent_id_e = frames_std_.find(",", symb_id_e + 1);
+          std::string parent_id_s = frames_std_.substr(symb_id_e + 1,
+                                                      s2_pos - parent_id_e - 1);
+          parent_id = atoi(parent_id_s.c_str());
+          TestFrameInfo info;
+          info.callsite_ = symbol_id;
+          info.frame_id_ = frame_id;
+          info.parent_ = parent_id;
+          frames_.push_back(info);
+          s1_pos = s2_pos + 1;
+        }
+      }
+    }
+  }
+
+  std::vector<Chunk> parseChunk(const std::string& chunk_std) {
+    std::vector<Chunk> chunks;
+    {
+      // parse chunks
+      size_t s1_pos = 0, s2_pos = 0;
+      unsigned time_begin, time_end, frame_id, type_id, size, number_of_objects;
+
+      while (s2_pos != chunk_std.npos) {
+        // look for the \n symbol
+        // format: frameId, symbolId, parentId
+        s2_pos = chunk_std.find("\n", s1_pos);
+        if (s2_pos != chunk_std.npos) {
+          int c1_e = chunk_std.find(",", s1_pos);
+          std::string c1_s = chunk_std.substr(s1_pos, c1_e - s1_pos);
+          time_begin = atoi(c1_s.c_str());
+
+          int c2_e = chunk_std.find(",", c1_e + 1);
+          std::string c2_s = chunk_std.substr(c1_e + 1, c2_e - c1_e - 1);
+          time_end = atoi(c2_s.c_str());
+
+          int c3_e = chunk_std.find(",", c2_e + 1);
+          std::string c3_s = chunk_std.substr(c2_e + 1, c3_e - c2_e - 1);
+          frame_id = atoi(c3_s.c_str());
+
+          int c4_e = chunk_std.find(",", c3_e + 1);
+          std::string c4_s = chunk_std.substr(c3_e + 1, c4_e - c3_e - 1);
+          type_id = atoi(c4_s.c_str());
+
+          int c5_e = chunk_std.find(",", c4_e + 1);
+          std::string c5_s = chunk_std.substr(c4_e + 1, c5_e - c4_e - 1);
+          size = atoi(c5_s.c_str());
+
+          int c6_e = chunk_std.find(",", c5_e + 1);
+          std::string c6_s = chunk_std.substr(c5_e + 1, c6_e - c5_e - 1);
+          number_of_objects = atoi(c6_s.c_str());
+
+          Chunk chunk;
+          chunk.frame_id_ = frame_id;
+          chunk.number_of_objects_ = number_of_objects;
+          chunk.size_ = size;
+          chunk.time_begin_ = time_begin;
+          chunk.time_end_ = time_end;
+          chunk.type_id_ = type_id;
+          chunks.push_back(chunk);
+          s1_pos = s2_pos + 1;
+        }
+      }
+    }
+    return chunks;
+  }
+
+ private:
+  size_t getFrameIdx(unsigned frame_id) {
+    for (size_t i = 0; i < frames_.size(); i++) {
+      if (frames_[i].frame_id_ == frame_id) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  std::vector<unsigned> findFrame(std::vector<std::string> bu_call_stack) {
+    std::vector<unsigned> frames;
+
+    std::map<std::string, unsigned>::const_iterator cit =
+        symbols_.find(bu_call_stack[0]);
+    if (cit != symbols_.end()) {
+        // take the cit->second and look for it in the frames
+      for (size_t j = 0; j < frames_.size(); j++) {
+        if (frames_[j].callsite_ == cit->second) {
+          bool good_frame = true;
+          // check all other frames iterating by parents
+          unsigned parent_frame = frames_[j].parent_;
+          for (size_t i = 1; i < bu_call_stack.size() && good_frame; i++) {
+            size_t idx = getFrameIdx(parent_frame);
+            if (idx != (size_t)-1) {
+              TestFrameInfo& parent = frames_[idx];
+              std::map<std::string, unsigned>::const_iterator cit2 =
+                  symbols_.find(bu_call_stack[i]);
+              if (cit2 != symbols_.end()) {
+                if (cit2->second == parent.callsite_) {
+                  parent_frame = parent.parent_;
+                } else {
+                  good_frame = false;
+                }
+              } else {
+                good_frame = false;
+              }
+            } else {
+              good_frame = false;
+            }
+          }
+          if (good_frame) {
+            frames.push_back(frames_[j].frame_id_);
+          }
+        }
+      }
+    }
+    return frames;
+  }
+  std::map<std::string, unsigned> symbols_;
+  std::map<std::string, unsigned> types_;
+  // no need to have fast version, it will not be many frames
+  std::vector<TestFrameInfo> frames_;
+};
+
+class TestStatsStreamXDK : public v8::OutputStream {
+ public:
+  explicit TestStatsStreamXDK(XDKHPOutputChecker* checker) :
+    checker_(checker) {}
+  virtual ~TestStatsStreamXDK() {}
+  virtual WriteResult WriteAsciiChunk(char* buffer, int chars_written) {
+    DCHECK(false);
+    return kAbort;
+  }
+  virtual WriteResult WriteHeapStatsChunk(v8::HeapStatsUpdate* data,
+                                          int count) {
+    DCHECK(false);
+    return kAbort;
+  }
+  virtual WriteResult WriteHeapXDKChunk(const char* symbols, int symbolsSize,
+    const char* frames, int framesSize,
+    const char* types, int typesSize,
+    const char* chunks, int chunksSize,
+    const char* retentions, int retentionSize) {
+    checker_->parse(symbols, frames, types);
+    chunk_ = chunks;
+    return kContinue;
+  }
+  void EndOfStream() {}
+
+  std::string GetChunk() {
+    return chunk_;
+  }
+
+ private:
+  XDKHPOutputChecker* checker_;
+  std::string chunk_;
+};
+
+
+TEST(HeapProfilerXDK) {
+  XDKHPOutputChecker checker;
+  LocalContext env2;
+  v8::HandleScope scope(env2->GetIsolate());
+  v8::HeapProfiler* heap_profiler = env2->GetIsolate()->GetHeapProfiler();
+  TestStatsStreamXDK stream(&checker);
+  heap_profiler->StartTrackingHeapObjectsXDK(8, false, true);
+
+  // To have repeatable test we need to warm-up the heap and optimization v8
+  // techniques (like inlining). So, we create 100 objects, not the only one
+  CompileRun(
+    "function A1() { this.string = 'This is a string';}\n"
+    "function object2() {\n"
+    "  this.elem = [];\n"
+    "  this.third = [];\n"
+    "}"
+    "var globalA2 = [];\n"
+    "function allocFunction2() {\n"
+    "  globalA2.push(new object2());\n"
+    "}\n"
+    "for (var i=0; i<100; i++) allocFunction2();\n");
+
+  heap_profiler->GetHeapXDKStats(&stream);
+  CompileRun("allocFunction2();\n");
+  heap_profiler->GetHeapXDKStats(&stream);
+  CompileRun("delete globalA2[99];\n");
+  heap_profiler->GetHeapXDKStats(&stream);
+  std::string chunk_deleted_globalA2_0_array = stream.GetChunk();
+  v8::HeapEventXDK* event = heap_profiler->StopTrackingHeapObjectsXDK();
+
+  // adding the latest info:
+  checker.parse(event->getSymbols(), event->getFrames(), event->getTypes());
+
+  // here should be 2 arrays and 1 object2
+  TestObjectInfo info_deleted_globalA2_0_array;
+  info_deleted_globalA2_0_array.bu_call_stack_.push_back("object2");
+  info_deleted_globalA2_0_array.bu_call_stack_.push_back("allocFunction2");
+  info_deleted_globalA2_0_array.type_ = "Array";
+  info_deleted_globalA2_0_array.number_of_objects_ = 0;
+  bool idg_arr_jad = checker.checkObjectsExists(
+      info_deleted_globalA2_0_array, chunk_deleted_globalA2_0_array);
+
+  TestObjectInfo info_deleted_globalA2_0;
+  info_deleted_globalA2_0.bu_call_stack_.push_back("allocFunction2");
+  info_deleted_globalA2_0.type_ = "object2";
+  info_deleted_globalA2_0.number_of_objects_ = 1;
+  bool idg_obj_jad = checker.checkObjectsExists(
+      info_deleted_globalA2_0, chunk_deleted_globalA2_0_array);
+
+  // here should be 2 arrays and 1 object2
+  TestObjectInfo info_deleted_globalA2_1_array;
+  info_deleted_globalA2_1_array.bu_call_stack_.push_back("object2");
+  info_deleted_globalA2_1_array.bu_call_stack_.push_back("allocFunction2");
+  info_deleted_globalA2_1_array.type_ = "Array";
+  info_deleted_globalA2_1_array.number_of_objects_ = 2;
+  bool idg_arr_end = checker.checkObjectsExists(
+      info_deleted_globalA2_1_array, event->getChunks());
+
+  TestObjectInfo info_deleted_globalA2_1;
+  info_deleted_globalA2_1.bu_call_stack_.push_back("allocFunction2");
+  info_deleted_globalA2_1.type_ = "object2";
+  info_deleted_globalA2_1.number_of_objects_ = 1;
+  bool idg_obj_end = checker.checkObjectsExists(
+      info_deleted_globalA2_1, event->getChunks());
+  // find objects anywhere
+  CHECK_EQ(true, idg_obj_end || idg_obj_jad);
+  CHECK_EQ(true, idg_arr_end || idg_arr_jad);
+}
+
+
+TEST(HeapProfilerXDKRetentionStorage) {
+  v8::internal::RefId parent;
+  v8::internal::RefId rf11, rf12, rf13, rf21, rf22, rf23;
+  v8::internal::RefSet set1, set2, set3;
+  v8::internal::References refs;
+
+  parent.stackId_ = 99;
+  parent.classId_ = 99;
+
+  rf11.stackId_ = 10; rf11.classId_ = 1; rf11.field_ = "one_";
+  set1.references_.insert(rf11);
+  rf12.stackId_ = 20; rf12.classId_ = 1; rf12.field_ = "two_";
+  set1.references_.insert(rf12);
+  rf13.stackId_ = 30; rf13.classId_ = 2; rf13.field_ = "three_";
+  set1.references_.insert(rf13);
+  refs.addReference(parent, set1, 0);
+
+  rf21.stackId_ = 10; rf21.classId_ = 1; rf21.field_ = "eno_";
+  set2.references_.insert(rf21);
+  rf22.stackId_ = 15; rf22.classId_ = 1; rf22.field_ = "owt_";
+  set2.references_.insert(rf22);
+  rf23.stackId_ = 30; rf23.classId_ = 2; rf23.field_ = "eerht_";
+  set2.references_.insert(rf23);
+  refs.addReference(parent, set2, 0);
+
+  set3.references_.insert(rf11);
+  set3.references_.insert(rf12);
+  set3.references_.insert(rf13);
+  refs.addReference(parent, set3, 0);
+
+  // there should be two records by set1 and one by set2
+  std::string str = refs.serialize();
+
+  CHECK_EQ(true,
+       str.find("99,99,1,0,2,10,1,one_,20,1,two_,30,2,three_") != str.npos &&
+       str.find("99,99,1,0,1,10,1,eno_,15,1,owt_,30,2,eerht_") != str.npos);
 }

--- a/tools/gyp/v8.gyp
+++ b/tools/gyp/v8.gyp
@@ -897,6 +897,10 @@
         '../../src/zone.h',
         '../../src/third_party/fdlibm/fdlibm.cc',
         '../../src/third_party/fdlibm/fdlibm.h',
+        '../../src/xdk-allocation.cc',
+        '../../src/xdk-allocation.h',
+        '../../src/xdk-utils.h',
+        '../../src/xdk-utils.cc',
       ],
       'conditions': [
         ['want_separate_host_toolset==1', {


### PR DESCRIPTION
There was several compilation errors after cherry-pick of XDK heap profiler 392f691 and 3901531 commits to chromium M42 version v8.
Bug fix consist of two parts
1. more strict warning handling. I believe they appear after clang usage
2. one of the construction in the v8 related to the marking of new block as FreeeSpace in the heap was slightly changed