### PR TITLE
Fix XDK code so that it uses size_t instead of int.

### DIFF
--- a/include/v8-profiler.h
+++ b/include/v8-profiler.h
@@ -332,12 +332,12 @@ class V8_EXPORT OutputStream {  // NOLINT
   /**
    * Writes XDK object
    */
-  virtual WriteResult WriteHeapXDKChunk(const char* symbols, int symbolsSize,
-                                        const char* frames, int framesSize,
-                                        const char* types, int typesSize,
-                                        const char* chunks, int chunksSize,
+  virtual WriteResult WriteHeapXDKChunk(const char* symbols, size_t symbolsSize,
+                                        const char* frames, size_t framesSize,
+                                        const char* types, size_t typesSize,
+                                        const char* chunks, size_t chunksSize,
                                         const char* retentions,
-                                        int retentionSize) {
+                                        size_t retentionSize) {
     return kAbort;
   }
 };

--- a/test/cctest/test-heap-profiler.cc
+++ b/test/cctest/test-heap-profiler.cc
@@ -3081,11 +3081,11 @@ class TestStatsStreamXDK : public v8::OutputStream {
     DCHECK(false);
     return kAbort;
   }
-  virtual WriteResult WriteHeapXDKChunk(const char* symbols, int symbolsSize,
-    const char* frames, int framesSize,
-    const char* types, int typesSize,
-    const char* chunks, int chunksSize,
-    const char* retentions, int retentionSize) {
+  virtual WriteResult WriteHeapXDKChunk(const char* symbols, size_t symbolsSize,
+    const char* frames, size_t framesSize,
+    const char* types, size_t typesSize,
+    const char* chunks, size_t chunksSize,
+    const char* retentions, size_t retentionSize) {
     checker_->parse(symbols, frames, types);
     chunk_ = chunks;
     return kContinue;


### PR DESCRIPTION
This is useful to support 64 bits because call sites of that
API usually uses std functions which returns a size_t and size_t
is not going to git into an int on 64 bits. Today it triggers a
warning of potential data loss.