### PR TITLE
XDK: Fix coding style for presubmit checks to pass.

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -7704,6 +7704,7 @@ void HeapSnapshot::Delete() {
   }
 }
 
+
 const char* HeapEventXDK::getSymbols() {
   const i::HeapEventXDK* eventXDK =
     reinterpret_cast<const i::HeapEventXDK*>(this);


### PR DESCRIPTION
src/api.cc does not have two empty lines between declarations in line 7705.