### PR TITLE
[SIMD.js] Implement conversion functions of partial simd128 data types i...

### DIFF
--- a/src/objects-inl.h
+++ b/src/objects-inl.h
@@ -1680,7 +1680,7 @@ int Int32x4::kRuntimeAllocatorId() {
 
 int32_t Int32x4::getAt(int index) {
   DCHECK(index >= 0 && index < kLanes);
-  return get().storage[index];;
+  return get().storage[index];
 }
 
 

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -196,11 +196,13 @@ namespace internal {
   F(Float32x4StoreXYZW, 3, 1)                  \
   F(Float32x4Abs, 1, 1)                        \
   F(Float32x4BitsToInt32x4, 1, 1)              \
+  F(Float32x4BitsToFloat64x2, 1, 1)            \
   F(Float32x4Neg, 1, 1)                        \
   F(Float32x4Reciprocal, 1, 1)                 \
   F(Float32x4ReciprocalSqrt, 1, 1)             \
   F(Float32x4Sqrt, 1, 1)                       \
   F(Float32x4ToInt32x4, 1, 1)                  \
+  F(Float32x4ToFloat64x2, 1, 1)                \
   F(Float32x4Add, 2, 1)                        \
   F(Float32x4Div, 2, 1)                        \
   F(Float32x4Max, 2, 1)                        \
@@ -226,9 +228,13 @@ namespace internal {
   F(Float64x2LoadXY, 2, 1)                     \
   F(Float64x2StoreX, 3, 1)                     \
   F(Float64x2StoreXY, 3, 1)                    \
+  F(Float64x2BitsToFloat32x4, 1, 1)            \
+  F(Float64x2BitsToInt32x4, 1, 1)              \
   F(Float64x2Abs, 1, 1)                        \
   F(Float64x2Neg, 1, 1)                        \
   F(Float64x2Sqrt, 1, 1)                       \
+  F(Float64x2ToFloat32x4, 1, 1)                \
+  F(Float64x2ToInt32x4, 1, 1)                  \
   F(Float64x2Add, 2, 1)                        \
   F(Float64x2Div, 2, 1)                        \
   F(Float64x2Max, 2, 1)                        \
@@ -250,9 +256,11 @@ namespace internal {
   F(Int32x4StoreXYZ, 3, 1)                     \
   F(Int32x4StoreXYZW, 3, 1)                    \
   F(Int32x4BitsToFloat32x4, 1, 1)              \
+  F(Int32x4BitsToFloat64x2, 1, 1)              \
   F(Int32x4Neg, 1, 1)                          \
   F(Int32x4Not, 1, 1)                          \
   F(Int32x4ToFloat32x4, 1, 1)                  \
+  F(Int32x4ToFloat64x2, 1, 1)                  \
   F(Int32x4And, 2, 1)                          \
   F(Int32x4Or, 2, 1)                           \
   F(Int32x4Xor, 2, 1)                          \

--- a/src/simd128.js
+++ b/src/simd128.js
@@ -200,11 +200,13 @@ SetUpInt32x4();
 macro SIMD128_UNARY_FUNCTIONS(FUNCTION)
 FUNCTION(Float32x4, Abs)
 FUNCTION(Float32x4, BitsToInt32x4)
+FUNCTION(Float32x4, BitsToFloat64x2)
 FUNCTION(Float32x4, Neg)
 FUNCTION(Float32x4, Reciprocal)
 FUNCTION(Float32x4, ReciprocalSqrt)
 FUNCTION(Float32x4, Sqrt)
 FUNCTION(Float32x4, ToInt32x4)
+FUNCTION(Float32x4, ToFloat64x2)
 FUNCTION(Float64x2, Abs)
 FUNCTION(Float64x2, Neg)
 FUNCTION(Float64x2, Sqrt)
@@ -212,6 +214,12 @@ FUNCTION(Int32x4, BitsToFloat32x4)
 FUNCTION(Int32x4, Neg)
 FUNCTION(Int32x4, Not)
 FUNCTION(Int32x4, ToFloat32x4)
+FUNCTION(Int32x4, ToFloat64x2)
+FUNCTION(Int32x4, BitsToFloat64x2)
+FUNCTION(Float64x2, ToFloat32x4)
+FUNCTION(Float64x2, BitsToFloat32x4)
+FUNCTION(Float64x2, ToInt32x4)
+FUNCTION(Float64x2, BitsToInt32x4)
 endmacro
 
 macro SIMD128_BINARY_FUNCTIONS(FUNCTION)
@@ -564,6 +572,8 @@ function SetUpSIMD() {
     "abs", Float32x4AbsJS,
     "fromInt32x4", Int32x4ToFloat32x4JS,
     "fromInt32x4Bits", Int32x4BitsToFloat32x4JS,
+    "fromFloat64x2", Float64x2ToFloat32x4JS,
+    "fromFloat64x2Bits", Float64x2BitsToFloat32x4JS,
     "neg", Float32x4NegJS,
     "reciprocal", Float32x4ReciprocalJS,
     "reciprocalSqrt", Float32x4ReciprocalSqrtJS,
@@ -613,6 +623,10 @@ function SetUpSIMD() {
     "abs", Float64x2AbsJS,
     "neg", Float64x2NegJS,
     "sqrt", Float64x2SqrtJS,
+    "fromFloat32x4", Float32x4ToFloat64x2JS,
+    "fromFloat32x4Bits", Float32x4BitsToFloat64x2JS,
+    "fromInt32x4", Int32x4ToFloat64x2JS,
+    "fromInt32x4Bits", Int32x4BitsToFloat64x2JS,
     // Binary
     "add", Float64x2AddJS,
     "div", Float64x2DivJS,
@@ -648,6 +662,8 @@ function SetUpSIMD() {
     // Unary
     "fromFloat32x4", Float32x4ToInt32x4JS,
     "fromFloat32x4Bits", Float32x4BitsToInt32x4JS,
+    "fromFloat64x2", Float64x2ToInt32x4JS,
+    "fromFloat64x2Bits", Float64x2BitsToInt32x4JS,
     "neg", Int32x4NegJS,
     "not", Int32x4NotJS,
     // Binary

--- a/test/mjsunit/simd/float32x4.js
+++ b/test/mjsunit/simd/float32x4.js
@@ -989,3 +989,61 @@ testFloat32x4Store();
 testFloat32x4Store();
 %OptimizeFunctionOnNextCall(testFloat32x4Store);
 testFloat32x4Store();
+
+function testSIMDFromInt32x4() {
+  var m = SIMD.float32x4(9, 10, 11, 12);
+  var nMask = SIMD.int32x4.fromFloat32x4(m);
+  var n = SIMD.float32x4.fromInt32x4(nMask);
+
+  assertEquals(9.0, n.x);
+  assertEquals(10.0, n.y);
+  assertEquals(11.0, n.z);
+  assertEquals(12.0, n.w);
+};
+
+testSIMDFromInt32x4();
+testSIMDFromInt32x4();
+%OptimizeFunctionOnNextCall(testSIMDFromInt32x4);
+testSIMDFromInt32x4();
+
+function testSIMDFromInt32x4Bits() {
+  var m = SIMD.float32x4(9, 10, 11, 12);
+  var nMask = SIMD.int32x4.fromFloat32x4Bits(m);
+  var n = SIMD.float32x4.fromInt32x4Bits(nMask);
+
+  assertEquals(9.0, n.x);
+  assertEquals(10.0, n.y);
+  assertEquals(11.0, n.z);
+  assertEquals(12.0, n.w);
+};
+
+testSIMDFromInt32x4Bits();
+testSIMDFromInt32x4Bits();
+%OptimizeFunctionOnNextCall(testSIMDFromInt32x4Bits);
+testSIMDFromInt32x4Bits();
+
+function testSIMDromFloat64x2() {
+  var m = SIMD.float32x4(9.0, 10.0, 11.0, 12.0);
+  var nMask = SIMD.float64x2.fromFloat32x4(m);
+  var n = SIMD.float32x4.fromFloat64x2(nMask);
+
+  assertEquals(9.0, n.x);
+  assertEquals(10.0, n.y);
+  assertEquals(0, n.z);
+  assertEquals(0, n.w);
+};
+
+testSIMDromFloat64x2();
+
+function testSIMDFromFloat64x2Bits() {
+  var m = SIMD.float32x4(9.0, 10.0, 11.0, 12.0);
+  var nMask = SIMD.float64x2.fromFloat32x4Bits(m);
+  var n = SIMD.float32x4.fromFloat64x2Bits(nMask);
+
+  assertEquals(9.0, n.x);
+  assertEquals(10.0, n.y);
+  assertEquals(11.0, n.z);
+  assertEquals(12.0, n.w);
+};
+
+testSIMDFromFloat64x2Bits()

--- a/test/mjsunit/simd/int32x4.js
+++ b/test/mjsunit/simd/int32x4.js
@@ -994,3 +994,29 @@ function testArrayOfInt32x4() {
 }
 
 testArrayOfInt32x4();
+
+function testSIMDFromFloat64x2() {
+  var m = SIMD.int32x4(9, 10, 11, 12);
+  var nMask = SIMD.float64x2.fromInt32x4(m);
+  var n = SIMD.int32x4.fromFloat64x2(nMask);
+
+  assertEquals(9, n.x);
+  assertEquals(10, n.y);
+  assertEquals(0, n.z);
+  assertEquals(0, n.w);
+}
+
+testSIMDFromFloat64x2();
+
+function testSIMDFromFloat64x2Bits() {
+  var m = SIMD.int32x4(9, 10, 11, 12);
+  var nMask = SIMD.float64x2.fromInt32x4Bits(m);
+  var n = SIMD.int32x4.fromFloat64x2Bits(nMask);
+
+  assertEquals(9, n.x);
+  assertEquals(10, n.y);
+  assertEquals(11, n.z);
+  assertEquals(12, n.w);
+}
+
+testSIMDFromFloat64x2Bits();


### PR DESCRIPTION
...n runtime.

The APIs include:
SIMD.float32x4.fromFloat64x2
SIMD.float32x4.fromFloat64x2Bits
SIMD.float64x2.fromFloat32x4
SIMD.float64x2.fromFloat32x4Bits
SIMD.int32x4.fromFloat64x2
SIMD.int32x4.fromFloat64x2Bits
SIMD.float64x2.fromInt32x4
SIMD.float64x2.fromInt32x4Bits

BUG=XWALK-3780