### PR TITLE
New feature for CPU Profiler - annotation of source lines by total time

### DIFF
--- a/include/v8-profiler.h
+++ b/include/v8-profiler.h
@@ -81,6 +81,11 @@ class V8_EXPORT CpuProfileNode {
   int GetColumnNumber() const;
 
   /**
+   * Returns source line connected with current ProfileNode
+  */
+  int GetSrcLine() const;
+
+  /**
    * Returns the number of the function's source lines that collect the samples.
    */
   unsigned int GetHitLineCount() const;

--- a/src/api.cc
+++ b/src/api.cc
@@ -7436,6 +7436,11 @@ int CpuProfileNode::GetColumnNumber() const {
       entry()->column_number();
 }
 
+int CpuProfileNode::GetSrcLine() const {
+  const i::ProfileNode* node = reinterpret_cast<const i::ProfileNode*>(this);
+  return node->src_line();
+}
+
 
 unsigned int CpuProfileNode::GetHitLineCount() const {
   const i::ProfileNode* node = reinterpret_cast<const i::ProfileNode*>(this);

--- a/src/profile-generator-inl.h
+++ b/src/profile-generator-inl.h
@@ -41,9 +41,10 @@ bool CodeEntry::is_js_function_tag(Logger::LogEventsAndTags tag) {
 }
 
 
-ProfileNode::ProfileNode(ProfileTree* tree, CodeEntry* entry)
+ProfileNode::ProfileNode(ProfileTree* tree, CodeEntry* entry, int src_line)
     : tree_(tree),
       entry_(entry),
+      src_line_(src_line),
       self_ticks_(0),
       children_(CodeEntriesMatch),
       id_(tree->next_node_id()),

--- a/src/profile-generator.h
+++ b/src/profile-generator.h
@@ -142,19 +142,38 @@ class CodeEntry {
 };
 
 
+struct StackEntry {
+ public:
+  explicit StackEntry(CodeEntry* e = NULL,
+           int line = v8::CpuProfileNode::kNoLineNumberInfo)
+    : entry(e),
+      srcLine(line) {}
+
+  CodeEntry* entry;
+  int srcLine;
+};
+
+
 class ProfileTree;
 
 class ProfileNode {
  public:
-  inline ProfileNode(ProfileTree* tree, CodeEntry* entry);
+  inline ProfileNode(ProfileTree* tree, CodeEntry* entry,
+                     int src_line = v8::CpuProfileNode::kNoLineNumberInfo);
 
+  ProfileNode* FindChild(StackEntry* stackentry);
+  ProfileNode* FindOrAddChild(StackEntry* stackentry);
+
+  // Supporting old functions
   ProfileNode* FindChild(CodeEntry* entry);
   ProfileNode* FindOrAddChild(CodeEntry* entry);
+
   void IncrementSelfTicks() { ++self_ticks_; }
   void IncreaseSelfTicks(unsigned amount) { self_ticks_ += amount; }
   void IncrementLineTicks(int src_line);
 
   CodeEntry* entry() const { return entry_; }
+  int src_line() const { return src_line_; }
   unsigned self_ticks() const { return self_ticks_; }
   const List<ProfileNode*>* children() const { return &children_list_; }
   unsigned id() const { return id_; }
@@ -181,6 +200,7 @@ class ProfileNode {
 
   ProfileTree* tree_;
   CodeEntry* entry_;
+  int src_line_;
   unsigned self_ticks_;
   // Mapping from CodeEntry* to ProfileNode*
   HashMap children_;
@@ -200,8 +220,14 @@ class ProfileTree {
   ~ProfileTree();
 
   ProfileNode* AddPathFromEnd(
+      const Vector<StackEntry>& path,
+      int src_line = v8::CpuProfileNode::kNoLineNumberInfo);
+
+  // Support old function
+  ProfileNode* AddPathFromEnd(
       const Vector<CodeEntry*>& path,
       int src_line = v8::CpuProfileNode::kNoLineNumberInfo);
+
   ProfileNode* root() const { return root_; }
   unsigned next_node_id() { return next_node_id_++; }
   unsigned GetFunctionId(const ProfileNode* node);
@@ -230,7 +256,7 @@ class CpuProfile {
   CpuProfile(const char* title, bool record_samples);
 
   // Add pc -> ... -> main() call path to the profile.
-  void AddPath(base::TimeTicks timestamp, const Vector<CodeEntry*>& path,
+  void AddPath(base::TimeTicks timestamp, const Vector<StackEntry>& path,
                int src_line);
   void CalculateTotalTicksAndSamplingRate();
 
@@ -338,7 +364,7 @@ class CpuProfilesCollection {
 
   // Called from profile generator thread.
   void AddPathToCurrentProfiles(base::TimeTicks timestamp,
-                                const Vector<CodeEntry*>& path, int src_line);
+                                const Vector<StackEntry>& path, int src_line);
 
   // Limits the number of profiles that can be simultaneously collected.
   static const int kMaxSimultaneousProfiles = 100;

--- a/test/cctest/test-profile-generator.cc
+++ b/test/cctest/test-profile-generator.cc
@@ -269,6 +269,80 @@ TEST(ProfileTreeCalculateTotalTicks) {
 }
 
 
+TEST(StackEntrys) {
+  // This test checks inserting and searching
+  // in tree using new structure - StackEntry
+  CodeEntry entry1(i::Logger::FUNCTION_TAG, "func1");
+  CodeEntry entry2(i::Logger::FUNCTION_TAG, "func2");
+  CodeEntry entry3(i::Logger::FUNCTION_TAG, "func3");
+  i::ProfileTree tree;
+  int line1 = 134;
+  int line2 = 257;
+  int line3 = 666;
+  i::StackEntry stackentry1(&entry1, line1);
+  i::StackEntry stackentry2(&entry2, line2);
+  i::StackEntry stackentry3(&entry3, line3);
+
+  // StackEntry structure is just an envelope for
+  // delivering pair [entry, source line] to Profile tree node
+  // It checks that StackEntry does its job well
+  i::StackEntry path[] = { stackentry3, stackentry2, stackentry1 };
+  Vector<i::StackEntry> path_vec(path, sizeof(path) / sizeof(path[0]));
+  tree.AddPathFromEnd(path_vec);
+  ProfileNode* node = tree.root();
+  CHECK(!node->FindChild(&stackentry2));
+  CHECK(!node->FindChild(&stackentry3));
+  ProfileNode* node1 = node->FindChild(&stackentry1);
+  CHECK(node1);
+  CHECK_EQ(0u, node1->self_ticks());
+  CHECK_EQ(line1, node1->src_line());
+  ProfileNode* node2 = node1->FindChild(&stackentry2);
+  CHECK(node2);
+  CHECK_EQ(0u, node2->self_ticks());
+  CHECK_EQ(line2, node2->src_line());
+  ProfileNode* node3 = node2->FindChild(&stackentry3);
+  CHECK(node3);
+  CHECK_EQ(1u, node3->self_ticks());
+  CHECK_EQ(line3, node3->src_line());
+  CHECK_NE(node1, node2);
+  CHECK_NE(node1, node3);
+  CHECK_NE(node2, node3);
+
+  // The second purpose of StackEntry is to separate pairs
+  // with the same entries, but different
+  // lines to different nodes
+  int line1s = 135;
+  int line2s = 256;
+  int line3s = 667;
+  i::StackEntry stackentry1s(&entry1, line1s);
+  i::StackEntry stackentry2s(&entry2, line2s);
+  i::StackEntry stackentry3s(&entry3, line3s);
+  i::StackEntry path2[] = { stackentry3s, stackentry2s, stackentry1s };
+  Vector<i::StackEntry> path_vec2(path2, sizeof(path2) / sizeof(path2[0]));
+
+  // It must create a separate branch in Profile tree
+  tree.AddPathFromEnd(path_vec2);
+  CHECK(!node->FindChild(&stackentry2s));
+  CHECK(!node->FindChild(&stackentry3s));
+  ProfileNode* node1s = node->FindChild(&stackentry1s);
+  CHECK(node1s);
+  CHECK_EQ(line1s, node1s->src_line());
+  ProfileNode* node2s = node1s->FindChild(&stackentry2s);
+  CHECK(node2s);
+  CHECK_EQ(line2s, node2s->src_line());
+  ProfileNode* node3s = node2s->FindChild(&stackentry3s);
+  CHECK(node3s);
+  CHECK_EQ(line3s, node3s->src_line());
+  CHECK_NE(node1s, node2s);
+  CHECK_NE(node1s, node3s);
+  CHECK_NE(node2s, node3s);
+
+  CHECK_NE(node1, node1s);
+  CHECK_NE(node2, node2s);
+  CHECK_NE(node3, node3s);
+}
+
+
 static inline i::Address ToAddress(int n) {
   return reinterpret_cast<i::Address>(n);
 }


### PR DESCRIPTION
This patch adds source lines annotations by total time values for the CPU profile.
It is planned to be up-streamed to Chromium v8. This functionality is required for XDK CPU profiling feature and can be used for CDT CPU profiling feature after frontend modification.

For source lines annotation by total time I added new StackEntry structure that substitutes CodeEntry class inside CPU profiling collection. StackEntry structure includes a pointer to CodeEntry object and
source line where certain sample happened or the callee function was called. This allows recording source line number for each node in the call tree. Previously, the source line was recorded only for the sample place, so we were not able to recover source lines of caller, that prevented calculating total time for source lines.

Thus the parsing stack functions use StackEntry's instances instead of CodeEntry. To store them in the hash I had to change the hash function that starts using not only CodeEntry, but also source line. Currently it looks like:
CodeEntryHash(old function for calculating hash) XOR (source_line from StackEntry structure). 
It is needed for separation of equal CodeEntries with different source lines. I checked efficiency of the new hash function in a separate test and obtained even better distribution inside HashMap than with the old function.

These changes don’t affect current CPU profiling results under CDT. The call tree stay the same because frontend merges the Nodes in the tree by CodeEntry hash only. And the source view is not annotated by the lines because it’s an open question how to do this properly for CDT views. CDT frontend should be extended to support both self-time annotations of the source lines and total times annotation.

Regarding transferring results to the frontend: these changes are transmitted to the frontend by adding new parameter src_line in ProfileNode token in the JSON based package. The corresponding changes are in the WebKit, patch that will be sent right after the merge of this pull request. 

I have changed the tests:
- I had to add wrappers for several functions which accept StackEntry by the functions, which accept old CodeEntry values to support existing tests.
- The new test for this functionality was added to 'test-profile-generator';
