### PR TITLE
Add maxNum and minNum for SIMD.Float32x4

### DIFF
--- a/src/ia32/lithium-codegen-ia32.cc
+++ b/src/ia32/lithium-codegen-ia32.cc
@@ -6587,7 +6587,9 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
     case kFloat32x4Mul:
     case kFloat32x4Div:
     case kFloat32x4Min:
-    case kFloat32x4Max: {
+    case kFloat32x4MinNum:
+    case kFloat32x4Max:
+    case kFloat32x4MaxNum: {
       DCHECK(instr->left()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->left()->representation().IsFloat32x4());
       DCHECK(instr->hydrogen()->right()->representation().IsFloat32x4());
@@ -6607,9 +6609,11 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
           __ divps(left_reg, right_reg);
           break;
         case kFloat32x4Min:
+        case kFloat32x4MinNum:
           __ minps(left_reg, right_reg);
           break;
         case kFloat32x4Max:
+        case kFloat32x4MaxNum:
           __ maxps(left_reg, right_reg);
           break;
         default:

--- a/src/ia32/lithium-ia32.cc
+++ b/src/ia32/lithium-ia32.cc
@@ -2923,7 +2923,9 @@ LInstruction* LChunkBuilder::DoBinarySIMDOperation(
     case kFloat32x4Add:
     case kFloat32x4Div:
     case kFloat32x4Max:
+    case kFloat32x4MaxNum:
     case kFloat32x4Min:
+    case kFloat32x4MinNum:
     case kFloat32x4Mul:
     case kFloat32x4Sub:
     case kFloat32x4Scale:

--- a/src/objects.h
+++ b/src/objects.h
@@ -6581,7 +6581,9 @@ class Script: public Struct {
   V(SIMD.Float32x4, add, Float32x4Add, Float32x4, Float32x4, Float32x4)        \
   V(SIMD.Float32x4, div, Float32x4Div, Float32x4, Float32x4, Float32x4)        \
   V(SIMD.Float32x4, max, Float32x4Max, Float32x4, Float32x4, Float32x4)        \
+  V(SIMD.Float32x4, maxNum, Float32x4MaxNum, Float32x4, Float32x4, Float32x4)  \
   V(SIMD.Float32x4, min, Float32x4Min, Float32x4, Float32x4, Float32x4)        \
+  V(SIMD.Float32x4, minNum, Float32x4MinNum, Float32x4, Float32x4, Float32x4)  \
   V(SIMD.Float32x4, mul, Float32x4Mul, Float32x4, Float32x4, Float32x4)        \
   V(SIMD.Float32x4, sub, Float32x4Sub, Float32x4, Float32x4, Float32x4)        \
   V(SIMD.Float32x4, equal, Float32x4Equal, Int32x4, Float32x4, Float32x4)      \

--- a/src/runtime/runtime-simd.cc
+++ b/src/runtime/runtime-simd.cc
@@ -486,11 +486,23 @@ static inline T Xor(T a, T b) {
 }
 
 
+static inline float MaxNum(float a, float b) {
+  return Max(a, b);
+}
+
+
+static inline float MinNum(float a, float b) {
+  return Min(a, b);
+}
+
+
 #define SIMD128_BINARY_FUNCTIONS(V)                           \
   V(Float32x4, Add, Float32x4)                                \
   V(Float32x4, Div, Float32x4)                                \
   V(Float32x4, Max, Float32x4)                                \
+  V(Float32x4, MaxNum, Float32x4)                             \
   V(Float32x4, Min, Float32x4)                                \
+  V(Float32x4, MinNum, Float32x4)                             \
   V(Float32x4, Mul, Float32x4)                                \
   V(Float32x4, Sub, Float32x4)                                \
   V(Float32x4, Equal, Int32x4)                                \

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -719,7 +719,9 @@ namespace internal {
   F(Float32x4Add, 2, 1)                        \
   F(Float32x4Div, 2, 1)                        \
   F(Float32x4Max, 2, 1)                        \
+  F(Float32x4MaxNum, 2, 1)                     \
   F(Float32x4Min, 2, 1)                        \
+  F(Float32x4MinNum, 2, 1)                     \
   F(Float32x4Mul, 2, 1)                        \
   F(Float32x4Sub, 2, 1)                        \
   F(Float32x4Equal, 2, 1)                      \

--- a/src/simd128.js
+++ b/src/simd128.js
@@ -248,7 +248,9 @@ macro SIMD128_BINARY_FUNCTIONS(FUNCTION)
 FUNCTION(Float32x4, Add)
 FUNCTION(Float32x4, Div)
 FUNCTION(Float32x4, Max)
+FUNCTION(Float32x4, MaxNum)
 FUNCTION(Float32x4, Min)
+FUNCTION(Float32x4, MinNum)
 FUNCTION(Float32x4, Mul)
 FUNCTION(Float32x4, Sub)
 FUNCTION(Float32x4, Equal)
@@ -629,7 +631,9 @@ function SetUpSIMD() {
     "add", Float32x4AddJS,
     "div", Float32x4DivJS,
     "max", Float32x4MaxJS,
+    "maxNum", Float32x4MaxNumJS,
     "min", Float32x4MinJS,
+    "minNum", Float32x4MinNumJS,
     "mul", Float32x4MulJS,
     "sub", Float32x4SubJS,
     "lessThan", Float32x4LessThanJS,

--- a/src/x64/lithium-codegen-x64.cc
+++ b/src/x64/lithium-codegen-x64.cc
@@ -4298,7 +4298,9 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
     case kFloat32x4Mul:
     case kFloat32x4Div:
     case kFloat32x4Min:
-    case kFloat32x4Max: {
+    case kFloat32x4MinNum:
+    case kFloat32x4Max:
+    case kFloat32x4MaxNum: {
       DCHECK(instr->left()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->left()->representation().IsFloat32x4());
       DCHECK(instr->hydrogen()->right()->representation().IsFloat32x4());
@@ -4318,9 +4320,11 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
           __ divps(left_reg, right_reg);
           break;
         case kFloat32x4Min:
+        case kFloat32x4MinNum:
           __ minps(left_reg, right_reg);
           break;
         case kFloat32x4Max:
+        case kFloat32x4MaxNum:
           __ maxps(left_reg, right_reg);
           break;
         default:

--- a/src/x64/lithium-x64.cc
+++ b/src/x64/lithium-x64.cc
@@ -1370,7 +1370,9 @@ LInstruction* LChunkBuilder::DoBinarySIMDOperation(
     case kFloat32x4Add:
     case kFloat32x4Div:
     case kFloat32x4Max:
+    case kFloat32x4MaxNum:
     case kFloat32x4Min:
+    case kFloat32x4MinNum:
     case kFloat32x4Mul:
     case kFloat32x4Sub:
     case kFloat32x4Scale:

--- a/test/mjsunit/simd/float32x4.js
+++ b/test/mjsunit/simd/float32x4.js
@@ -27,6 +27,7 @@
 
 // Flags: --simd-object --allow-natives-syntax
 
+
 function testConstructor() {
   var f4 = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
   assertEquals(1.0, SIMD.Float32x4.extractLane(f4, 0));
@@ -753,3 +754,26 @@ testSIMDReplaceLane();
 testSIMDReplaceLane();
 %OptimizeFunctionOnNextCall(testSIMDReplaceLane);
 testSIMDReplaceLane();
+
+function testSIMDMaxNum() {
+  var m = SIMD.Float32x4(1.0, 2.0, 5.0, 6.0);
+  var n = SIMD.Float32x4(0.0, 4.0, 5.0, 7.0);
+  var m = SIMD.Float32x4.maxNum(m, n);
+  assertEquals(1.0, SIMD.Float32x4.extractLane(m, 0));
+  assertEquals(4.0, SIMD.Float32x4.extractLane(m, 1));
+  assertEquals(5.0, SIMD.Float32x4.extractLane(m, 2));
+  assertEquals(7.0, SIMD.Float32x4.extractLane(m, 3));
+}
+testSIMDMaxNum();
+
+
+function testSIMDMinNum() {
+  var m = SIMD.Float32x4(1.0, 2.0, 5.0, 6.0);
+  var n = SIMD.Float32x4(0.0, 4.0, 5.0, 7.0);
+  var m = SIMD.Float32x4.minNum(m, n);
+  assertEquals(1.0, SIMD.Float32x4.extractLane(m, 0));
+  assertEquals(2.0, SIMD.Float32x4.extractLane(m, 1));
+  assertEquals(5.0, SIMD.Float32x4.extractLane(m, 2));
+  assertEquals(6.0, SIMD.Float32x4.extractLane(m, 3));
+}
+testSIMDMaxNum();

--- a/test/mjsunit/simd/float32x4.js
+++ b/test/mjsunit/simd/float32x4.js
@@ -765,7 +765,9 @@ function testSIMDMaxNum() {
   assertEquals(7.0, SIMD.Float32x4.extractLane(m, 3));
 }
 testSIMDMaxNum();
-
+testSIMDMaxNum();
+%OptimizeFunctionOnNextCall(testSIMDMaxNum);
+testSIMDMaxNum();
 
 function testSIMDMinNum() {
   var m = SIMD.Float32x4(1.0, 2.0, 5.0, 6.0);
@@ -776,4 +778,7 @@ function testSIMDMinNum() {
   assertEquals(5.0, SIMD.Float32x4.extractLane(m, 2));
   assertEquals(6.0, SIMD.Float32x4.extractLane(m, 3));
 }
+testSIMDMaxNum();
+testSIMDMaxNum();
+%OptimizeFunctionOnNextCall(testSIMDMaxNum);
 testSIMDMaxNum();


### PR DESCRIPTION
There have two requirements to implement these two apis: Add maxNum and minNum for Float32x4.
One is that implementation need to be aligned with simd new spec: http://tc39.github.io/ecmascript_simd/. The other is these two apis will help to enable neweast benchmark.
BUG=XWALK-4768.