### PR TITLE
[SIMD.js] Add Float64x2 and Bool64x2 types and some operations

### DIFF
--- a/include/v8.h
+++ b/include/v8.h
@@ -6948,7 +6948,7 @@ class Internals {
   static const int kJSObjectHeaderSize = 3 * kApiPointerSize;
   static const int kFixedArrayHeaderSize = 2 * kApiPointerSize;
   static const int kContextHeaderSize = 2 * kApiPointerSize;
-  static const int kContextEmbedderDataIndex = 27;
+  static const int kContextEmbedderDataIndex = 29;
   static const int kFullStringRepresentationMask = 0x07;
   static const int kStringEncodingMask = 0x4;
   static const int kExternalTwoByteRepresentationTag = 0x02;

--- a/src/contexts.h
+++ b/src/contexts.h
@@ -82,7 +82,9 @@ enum BindingFlags {
   V(STRING_FUNCTION_PROTOTYPE_MAP_INDEX, Map, string_function_prototype_map)   \
   V(SYMBOL_FUNCTION_INDEX, JSFunction, symbol_function)                        \
   V(FLOAT32X4_FUNCTION_INDEX, JSFunction, float32x4_function)                  \
+  V(FLOAT64x2_FUNCTION_INDEX, JSFunction, float64x2_function)                  \
   V(INT32X4_FUNCTION_INDEX, JSFunction, int32x4_function)                      \
+  V(BOOL64x2_FUNCTION_INDEX, JSFunction, bool64x2_function)                    \
   V(BOOL32X4_FUNCTION_INDEX, JSFunction, bool32x4_function)                    \
   V(INT16X8_FUNCTION_INDEX, JSFunction, int16x8_function)                      \
   V(BOOL16X8_FUNCTION_INDEX, JSFunction, bool16x8_function)                    \

--- a/src/globals.h
+++ b/src/globals.h
@@ -95,6 +95,16 @@ typedef byte* Address;
 // -----------------------------------------------------------------------------
 // Constants
 
+struct float32x4_value_t { float storage[4]; };
+struct float64x2_value_t { double storage[2]; };
+struct int32x4_value_t { int32_t storage[4]; };
+union simd128_value_t {
+  double d[2];
+  float32x4_value_t f4;
+  float64x2_value_t d2;
+  int32x4_value_t i4;
+};
+
 const int KB = 1024;
 const int MB = KB * KB;
 const int GB = KB * KB * KB;

--- a/src/harmony-simd.js
+++ b/src/harmony-simd.js
@@ -15,6 +15,7 @@ var GlobalSIMD = global.SIMD;
 
 macro SIMD_FLOAT_TYPES(FUNCTION)
 FUNCTION(Float32x4, float32x4, 4)
+FUNCTION(Float64x2, float64x2, 2)
 endmacro
 
 macro SIMD_INT_TYPES(FUNCTION)
@@ -24,6 +25,7 @@ FUNCTION(Int8x16, int8x16, 16)
 endmacro
 
 macro SIMD_BOOL_TYPES(FUNCTION)
+FUNCTION(Bool64x2, bool64x2, 2)
 FUNCTION(Bool32x4, bool32x4, 4)
 FUNCTION(Bool16x8, bool16x8, 8)
 FUNCTION(Bool8x16, bool8x16, 16)
@@ -227,6 +229,8 @@ SIMD_LOGICAL_TYPES(DECLARE_LOGICAL_FUNCTIONS)
 macro SIMD_FROM_TYPES(FUNCTION)
 FUNCTION(Float32x4, Int32x4)
 FUNCTION(Int32x4, Float32x4)
+FUNCTION(Float64x2, Int32x4)
+FUNCTION(Float64x2, Float32x4)
 endmacro
 
 macro DECLARE_FROM_FUNCTIONS(TO, FROM)
@@ -241,6 +245,8 @@ macro SIMD_FROM_BITS_TYPES(FUNCTION)
 FUNCTION(Float32x4, Int32x4)
 FUNCTION(Float32x4, Int16x8)
 FUNCTION(Float32x4, Int8x16)
+FUNCTION(Float64x2, Int32x4)
+FUNCTION(Float64x2, Float32x4)
 FUNCTION(Int32x4, Float32x4)
 FUNCTION(Int32x4, Int16x8)
 FUNCTION(Int32x4, Int8x16)
@@ -319,6 +325,61 @@ function Float32x4ShuffleJS(a, b, c0, c1, c2, c3) {
 }
 
 
+function Float64x2Constructor(c0, c1) {
+  if (%_IsConstructCall()) throw MakeTypeError(kNotConstructor, "Float64x2");
+  return %CreateFloat64x2(TO_NUMBER_INLINE(c0), TO_NUMBER_INLINE(c1));
+}
+
+
+function Float64x2Splat(s) {
+  return %CreateFloat64x2(s, s);
+}
+
+
+function Float64x2AbsJS(a) {
+  return %Float64x2Abs(a);
+}
+
+
+function Float64x2SqrtJS(a) {
+  return %Float64x2Sqrt(a);
+}
+
+
+function Float64x2RecipApproxJS(a) {
+  return %Float64x2RecipApprox(a);
+}
+
+
+function Float64x2RecipSqrtApproxJS(a) {
+  return %Float64x2RecipSqrtApprox(a);
+}
+
+
+function Float64x2DivJS(a, b) {
+  return %Float64x2Div(a, b);
+}
+
+
+function Float64x2MinNumJS(a, b) {
+  return %Float64x2MinNum(a, b);
+}
+
+
+function Float64x2MaxNumJS(a, b) {
+  return %Float64x2MaxNum(a, b);
+}
+
+
+function Float64x2SwizzleJS(a, c0, c1) {
+  return %Float64x2Swizzle(a, c0, c1);
+}
+
+
+function Float64x2ShuffleJS(a, b, c0, c1) {
+  return %Float64x2Shuffle(a, b, c0, c1);
+}
+
 function Int32x4Constructor(c0, c1, c2, c3) {
   if (%_IsConstructCall()) throw MakeTypeError(kNotConstructor, "Int32x4");
   return %CreateInt32x4(TO_NUMBER_INLINE(c0), TO_NUMBER_INLINE(c1),
@@ -340,6 +401,25 @@ function Int32x4ShuffleJS(a, b, c0, c1, c2, c3) {
   return %Int32x4Shuffle(a, b, c0, c1, c2, c3);
 }
 
+
+function Bool64x2Constructor(c0, c1) {
+  if (%_IsConstructCall()) throw MakeTypeError(kNotConstructor, "Bool64x2");
+  return %CreateBool64x2(c0, c1);
+}
+
+
+function Bool64x2Splat(s) {
+  return %CreateBool64x2(s, s);
+}
+
+function Bool64x2SwizzleJS(a, c0, c1) {
+  return %Bool64x2Swizzle(a, c0, c1);
+}
+
+
+function Bool64x2ShuffleJS(a, b, c0, c1) {
+  return %Bool64x2Shuffle(a, b, c0, c1);
+}
 
 function Bool32x4Constructor(c0, c1, c2, c3) {
   if (%_IsConstructCall()) throw MakeTypeError(kNotConstructor, "Bool32x4");
@@ -484,11 +564,40 @@ endmacro
 
 SIMD_ALL_TYPES(SETUP_SIMD_TYPE)
 
+macro DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(TYPE, LANES)
+function TYPELoadLANESJS(tarray, index) {
+  return tarray._getTYPELANES(index);
+}
+
+function TYPEStoreLANESJS(tarray, index, value) {
+  tarray._setTYPELANES(index, value);
+}
+endmacro
+
+DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(Float32x4, XYZW)
+DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(Float32x4, XYZ)
+DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(Float32x4, XY)
+DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(Float32x4, X)
+DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(Float64x2, XY)
+DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(Float64x2, X)
+DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(Int32x4, XYZW)
+DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(Int32x4, XYZ)
+DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(Int32x4, XY)
+DECLARE_SIMD_LOAD_AND_STORE_FUNCTION(Int32x4, X)
+
 //-------------------------------------------------------------------
 
 utils.InstallFunctions(GlobalFloat32x4, DONT_ENUM, [
   'splat', Float32x4Splat,
   'check', Float32x4CheckJS,
+  'load', Float32x4LoadXYZWJS,
+  'loadX', Float32x4LoadXJS,
+  'loadXY', Float32x4LoadXYJS,
+  'loadXYZ', Float32x4LoadXYZJS,
+  'store', Float32x4StoreXYZWJS,
+  'storeX', Float32x4StoreXJS,
+  'storeXY', Float32x4StoreXYJS,
+  'storeXYZ', Float32x4StoreXYZJS,
   'extractLane', Float32x4ExtractLaneJS,
   'replaceLane', Float32x4ReplaceLaneJS,
   'neg', Float32x4NegJS,
@@ -519,9 +628,54 @@ utils.InstallFunctions(GlobalFloat32x4, DONT_ENUM, [
   'fromInt8x16Bits', Float32x4FromInt8x16BitsJS,
 ]);
 
+utils.InstallFunctions(GlobalFloat64x2, DONT_ENUM, [
+  'splat', Float64x2Splat,
+  'check', Float64x2CheckJS,
+  'load', Float64x2LoadXYJS,
+  'loadX', Float64x2LoadXJS,
+  'store', Float64x2StoreXYJS,
+  'storeX', Float64x2StoreXJS,
+  'extractLane', Float64x2ExtractLaneJS,
+  'replaceLane', Float64x2ReplaceLaneJS,
+  'neg', Float64x2NegJS,
+  'abs', Float64x2AbsJS,
+  'sqrt', Float64x2SqrtJS,
+  'reciprocalApproximation', Float64x2RecipApproxJS,
+  'reciprocalSqrtApproximation', Float64x2RecipSqrtApproxJS,
+  'add', Float64x2AddJS,
+  'sub', Float64x2SubJS,
+  'mul', Float64x2MulJS,
+  'div', Float64x2DivJS,
+  'min', Float64x2MinJS,
+  'max', Float64x2MaxJS,
+  'minNum', Float64x2MinNumJS,
+  'maxNum', Float64x2MaxNumJS,
+  'lessThan', Float64x2LessThanJS,
+  'lessThanOrEqual', Float64x2LessThanOrEqualJS,
+  'greaterThan', Float64x2GreaterThanJS,
+  'greaterThanOrEqual', Float64x2GreaterThanOrEqualJS,
+  'equal', Float64x2EqualJS,
+  'notEqual', Float64x2NotEqualJS,
+  'select', Float64x2SelectJS,
+  'swizzle', Float64x2SwizzleJS,
+  'shuffle', Float64x2ShuffleJS,
+  'fromInt32x4', Float64x2FromInt32x4JS,
+  'fromInt32x4Bits', Float64x2FromInt32x4BitsJS,
+  'fromFloat32x4', Float64x2FromFloat32x4JS,
+  'fromFloat32x4Bits', Float64x2FromFloat32x4BitsJS,
+]);
+
 utils.InstallFunctions(GlobalInt32x4, DONT_ENUM, [
   'splat', Int32x4Splat,
   'check', Int32x4CheckJS,
+  'load', Int32x4LoadXYZWJS,
+  'loadX', Int32x4LoadXJS,
+  'loadXY', Int32x4LoadXYJS,
+  'loadXYZ', Int32x4LoadXYZJS,
+  'store', Int32x4StoreXYZWJS,
+  'storeX', Int32x4StoreXJS,
+  'storeXY', Int32x4StoreXYJS,
+  'storeXYZ', Int32x4StoreXYZJS,
   'extractLane', Int32x4ExtractLaneJS,
   'replaceLane', Int32x4ReplaceLaneJS,
   'neg', Int32x4NegJS,
@@ -550,6 +704,23 @@ utils.InstallFunctions(GlobalInt32x4, DONT_ENUM, [
   'fromFloat32x4Bits', Int32x4FromFloat32x4BitsJS,
   'fromInt16x8Bits', Int32x4FromInt16x8BitsJS,
   'fromInt8x16Bits', Int32x4FromInt8x16BitsJS,
+]);
+
+utils.InstallFunctions(GlobalBool64x2, DONT_ENUM, [
+  'splat', Bool64x2Splat,
+  'check', Bool64x2CheckJS,
+  'extractLane', Bool64x2ExtractLaneJS,
+  'replaceLane', Bool64x2ReplaceLaneJS,
+  'and', Bool64x2AndJS,
+  'or', Bool64x2OrJS,
+  'xor', Bool64x2XorJS,
+  'not', Bool64x2NotJS,
+  'anyTrue', Bool64x2AnyTrueJS,
+  'allTrue', Bool64x2AllTrueJS,
+  'equal', Bool64x2EqualJS,
+  'notEqual', Bool64x2NotEqualJS,
+  'swizzle', Bool64x2SwizzleJS,
+  'shuffle', Bool64x2ShuffleJS,
 ]);
 
 utils.InstallFunctions(GlobalBool32x4, DONT_ENUM, [
@@ -668,6 +839,129 @@ utils.InstallFunctions(GlobalBool8x16, DONT_ENUM, [
   'swizzle', Bool8x16SwizzleJS,
   'shuffle', Bool8x16ShuffleJS,
 ]);
+
+//------------------------------------------------------------------------------
+
+function TypedArrayGetToStringTag() {
+  if (!%_IsTypedArray(this)) return;
+  var name = %_ClassOf(this);
+  if (IS_UNDEFINED(name)) return;
+  return name;
+}
+
+
+// --------------------SIMD128 Access in Typed Array -----------------
+var Uint8Array = global.Uint8Array;
+var Int8Array = global.Int8Array;
+var Uint16Array = global.Uint16Array;
+var Int16Array = global.Int16Array;
+var Uint32Array = global.Uint32Array;
+var Int32Array = global.Int32Array;
+var Float32Array = global.Float32Array;
+var Float64Array = global.Float64Array;
+
+macro DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, TYPE, LANES, NBYTES)
+function VIEWGetTYPELANESJS(index) {
+  if (!(%_ClassOf(this) === 'VIEW')) {
+    throw MakeTypeError('incompatible_method_receiver',
+                        ["VIEW._getTYPELANES", this]);
+  }
+  var tarray = this;
+  if (%_ArgumentsLength() < 1) {
+    throw MakeTypeError('invalid_argument');
+  }
+  if (!IS_NUMBER(index)) {
+    throw MakeTypeError('The 2nd argument must be a Number.');
+  }
+  var offset = TO_INTEGER(index) * tarray.BYTES_PER_ELEMENT + tarray.byteOffset;
+  if (offset < tarray.byteOffset || (offset + NBYTES) > (tarray.byteLength + tarray.byteOffset))
+    throw MakeRangeError('The value of index is invalid.');
+  var arraybuffer = tarray.buffer;
+  return %TYPELoadLANES(arraybuffer, offset);
+}
+
+function VIEWSetTYPELANESJS(index, value) {
+
+  if (!(%_ClassOf(this) === 'VIEW')) {
+    throw MakeTypeError('incompatible_method_receiver',
+                        ["VIEW._setTYPELANES", this]);
+  }
+  var tarray = this;
+  if (%_ArgumentsLength() < 2) {
+    throw MakeTypeError('invalid_argument');
+  }
+  if (!IS_NUMBER(index)) {
+    throw MakeTypeError('The 2nd argument must be a Number.');
+  }
+
+  var offset = TO_INTEGER(index) * tarray.BYTES_PER_ELEMENT + tarray.byteOffset;
+  if (offset < tarray.byteOffset || (offset + NBYTES) > (tarray.byteLength + tarray.byteOffset))
+    throw MakeRangeError('The value of index is invalid.');
+  var arraybuffer = tarray.buffer;
+  %TYPEStoreLANES(arraybuffer, offset, value);
+
+}
+endmacro
+
+macro DECLARE_VIEW_SIMD_LOAD_AND_STORE_FUNCTION(VIEW)
+DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, Float32x4, XYZW, 16)
+DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, Float32x4, XYZ, 12)
+DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, Float32x4, XY, 8)
+DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, Float32x4, X, 4)
+DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, Float64x2, XY, 16)
+DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, Float64x2, X, 8)
+DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, Int32x4, XYZW, 16)
+DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, Int32x4, XYZ, 12)
+DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, Int32x4, XY, 8)
+DECLARE_TYPED_ARRAY_SIMD_LOAD_AND_STORE_FUNCTION(VIEW, Int32x4, X, 4)
+endmacro
+
+DECLARE_VIEW_SIMD_LOAD_AND_STORE_FUNCTION(Uint8Array)
+DECLARE_VIEW_SIMD_LOAD_AND_STORE_FUNCTION(Int8Array)
+DECLARE_VIEW_SIMD_LOAD_AND_STORE_FUNCTION(Uint16Array)
+DECLARE_VIEW_SIMD_LOAD_AND_STORE_FUNCTION(Int16Array)
+DECLARE_VIEW_SIMD_LOAD_AND_STORE_FUNCTION(Uint32Array)
+DECLARE_VIEW_SIMD_LOAD_AND_STORE_FUNCTION(Int32Array)
+DECLARE_VIEW_SIMD_LOAD_AND_STORE_FUNCTION(Float32Array)
+DECLARE_VIEW_SIMD_LOAD_AND_STORE_FUNCTION(Float64Array)
+
+function SetupTypedArraysSimdLoadStore() {
+macro DECLARE_INSTALL_SIMD_LOAD_AND_STORE_FUNCTION(VIEW)
+  utils.InstallFunctions(VIEW.prototype, DONT_ENUM, [
+      "_getFloat32x4X", VIEWGetFloat32x4XJS,
+      "_setFloat32x4X", VIEWSetFloat32x4XJS,
+      "_getFloat32x4XY", VIEWGetFloat32x4XYJS,
+      "_setFloat32x4XY", VIEWSetFloat32x4XYJS,
+      "_getFloat32x4XYZ", VIEWGetFloat32x4XYZJS,
+      "_setFloat32x4XYZ", VIEWSetFloat32x4XYZJS,
+      "_getFloat32x4XYZW", VIEWGetFloat32x4XYZWJS,
+      "_setFloat32x4XYZW", VIEWSetFloat32x4XYZWJS,
+      "_getFloat64x2X", VIEWGetFloat64x2XJS,
+      "_setFloat64x2X", VIEWSetFloat64x2XJS,
+      "_getFloat64x2XY", VIEWGetFloat64x2XYJS,
+      "_setFloat64x2XY", VIEWSetFloat64x2XYJS,
+      "_getInt32x4X", VIEWGetInt32x4XJS,
+      "_setInt32x4X", VIEWSetInt32x4XJS,
+      "_getInt32x4XY", VIEWGetInt32x4XYJS,
+      "_setInt32x4XY", VIEWSetInt32x4XYJS,
+      "_getInt32x4XYZ", VIEWGetInt32x4XYZJS,
+      "_setInt32x4XYZ", VIEWSetInt32x4XYZJS,
+      "_getInt32x4XYZW", VIEWGetInt32x4XYZWJS,
+      "_setInt32x4XYZW", VIEWSetInt32x4XYZWJS
+  ]);
+endmacro
+
+DECLARE_INSTALL_SIMD_LOAD_AND_STORE_FUNCTION(Uint8Array)
+DECLARE_INSTALL_SIMD_LOAD_AND_STORE_FUNCTION(Int8Array)
+DECLARE_INSTALL_SIMD_LOAD_AND_STORE_FUNCTION(Uint16Array)
+DECLARE_INSTALL_SIMD_LOAD_AND_STORE_FUNCTION(Int16Array)
+DECLARE_INSTALL_SIMD_LOAD_AND_STORE_FUNCTION(Uint32Array)
+DECLARE_INSTALL_SIMD_LOAD_AND_STORE_FUNCTION(Int32Array)
+DECLARE_INSTALL_SIMD_LOAD_AND_STORE_FUNCTION(Float32Array)
+DECLARE_INSTALL_SIMD_LOAD_AND_STORE_FUNCTION(Float64Array)
+}
+
+SetupTypedArraysSimdLoadStore();
 
 utils.Export(function(to) {
   to.Float32x4ToString = Float32x4ToString;

--- a/src/heap/heap.h
+++ b/src/heap/heap.h
@@ -46,7 +46,9 @@ namespace internal {
   V(Map, heap_number_map, HeapNumberMap)                                       \
   V(Map, mutable_heap_number_map, MutableHeapNumberMap)                        \
   V(Map, float32x4_map, Float32x4Map)                                          \
+  V(Map, float64x2_map, Float64x2Map)                                          \
   V(Map, int32x4_map, Int32x4Map)                                              \
+  V(Map, bool64x2_map, Bool64x2Map)                                            \
   V(Map, bool32x4_map, Bool32x4Map)                                            \
   V(Map, int16x8_map, Int16x8Map)                                              \
   V(Map, bool16x8_map, Bool16x8Map)                                            \
@@ -217,8 +219,12 @@ namespace internal {
   V(eval_string, "eval")                                       \
   V(float32x4_string, "float32x4")                             \
   V(Float32x4_string, "Float32x4")                             \
+  V(float64x2_string, "float64x2")                             \
+  V(Float64x2_string, "Float64x2")                             \
   V(int32x4_string, "int32x4")                                 \
   V(Int32x4_string, "Int32x4")                                 \
+  V(bool64x2_string, "bool64x2")                               \
+  V(Bool64x2_string, "Bool64x2")                               \
   V(bool32x4_string, "bool32x4")                               \
   V(Bool32x4_string, "Bool32x4")                               \
   V(int16x8_string, "int16x8")                                 \

--- a/src/messages.h
+++ b/src/messages.h
@@ -275,6 +275,7 @@ class CallSite {
   T(TypedArraySetSourceTooLarge, "Source is too large")                        \
   T(UnsupportedTimeZone, "Unsupported time zone specified %")                  \
   T(ValueOutOfRange, "Value % out of range for % options property %")          \
+  T(InvalidOffset, "invalid_offset")                                           \
   /* SyntaxError */                                                            \
   T(BadGetterArity, "Getter must not have any formal parameters.")             \
   T(BadSetterArity, "Setter must have exactly one formal parameter.")          \

--- a/src/objects-inl.h
+++ b/src/objects-inl.h
@@ -1593,6 +1593,7 @@ SIMD128_TYPES(SIMD128_VALUE_EQUALS)
   }
 
 SIMD128_NUMERIC_LANE_FNS(Float32x4, float, 4, FLOAT, kFloatSize)
+SIMD128_NUMERIC_LANE_FNS(Float64x2, double, 2, DOUBLE, kDoubleSize)
 SIMD128_NUMERIC_LANE_FNS(Int32x4, int32_t, 4, INT32, kInt32Size)
 SIMD128_NUMERIC_LANE_FNS(Int16x8, int16_t, 8, INT16, kShortSize)
 SIMD128_NUMERIC_LANE_FNS(Int8x16, int8_t, 16, INT8, kCharSize)
@@ -1614,6 +1615,7 @@ SIMD128_NUMERIC_LANE_FNS(Int8x16, int8_t, 16, INT8, kCharSize)
     SIMD128_WRITE_LANE(lane_count, field_type, field_size, int_val)       \
   }
 
+SIMD128_BOOLEAN_LANE_FNS(Bool64x2, int64_t, 2, INT64, kInt64Size)
 SIMD128_BOOLEAN_LANE_FNS(Bool32x4, int32_t, 4, INT32, kInt32Size)
 SIMD128_BOOLEAN_LANE_FNS(Bool16x8, int16_t, 8, INT16, kShortSize)
 SIMD128_BOOLEAN_LANE_FNS(Bool8x16, int8_t, 16, INT8, kCharSize)
@@ -3235,6 +3237,7 @@ void SeededNumberDictionary::set_requires_slow_elements() {
 
 CAST_ACCESSOR(AccessorInfo)
 CAST_ACCESSOR(ArrayList)
+CAST_ACCESSOR(Bool64x2)
 CAST_ACCESSOR(Bool16x8)
 CAST_ACCESSOR(Bool32x4)
 CAST_ACCESSOR(Bool8x16)
@@ -3257,6 +3260,7 @@ CAST_ACCESSOR(FixedArrayBase)
 CAST_ACCESSOR(FixedDoubleArray)
 CAST_ACCESSOR(FixedTypedArrayBase)
 CAST_ACCESSOR(Float32x4)
+CAST_ACCESSOR(Float64x2)
 CAST_ACCESSOR(Foreign)
 CAST_ACCESSOR(GlobalDictionary)
 CAST_ACCESSOR(GlobalObject)

--- a/src/objects-printer.cc
+++ b/src/objects-printer.cc
@@ -210,6 +210,14 @@ void Float32x4::Float32x4Print(std::ostream& os) {  // NOLINT
 }
 
 
+void Float64x2::Float64x2Print(std::ostream& os) {  // NOLINT
+  char arr[100];
+  Vector<char> buffer(arr, arraysize(arr));
+  os << std::string(DoubleToCString(get_lane(0), buffer)) << ", "
+     << std::string(DoubleToCString(get_lane(1), buffer));
+}
+
+
 #define SIMD128_INT_PRINT_FUNCTION(type, lane_count)                \
   void type::type##Print(std::ostream& os) {                        \
     char arr[100];                                                  \
@@ -234,6 +242,7 @@ SIMD128_INT_PRINT_FUNCTION(Int8x16, 16)
       os << ", " << std::string(get_lane(i) ? "true" : "false"); \
     }                                                            \
   }
+SIMD128_BOOL_PRINT_FUNCTION(Bool64x2, 2)
 SIMD128_BOOL_PRINT_FUNCTION(Bool32x4, 4)
 SIMD128_BOOL_PRINT_FUNCTION(Bool16x8, 8)
 SIMD128_BOOL_PRINT_FUNCTION(Bool8x16, 16)

--- a/src/objects.cc
+++ b/src/objects.cc
@@ -735,6 +735,16 @@ bool Object::SameValue(Object* other) {
         if (std::signbit(x) != std::signbit(y)) return false;
       }
       return true;
+    } else if (IsFloat64x2() && other->IsFloat64x2()) {
+      Float64x2* a = Float64x2::cast(this);
+      Float64x2* b = Float64x2::cast(other);
+      for (int i = 0; i < 2; i++) {
+        double x = a->get_lane(i);
+        double y = b->get_lane(i);
+        if (x != y && !(std::isnan(x) && std::isnan(y))) return false;
+        if (std::signbit(x) != std::signbit(y)) return false;
+      }
+      return true;
     } else {
       Simd128Value* a = Simd128Value::cast(this);
       Simd128Value* b = Simd128Value::cast(other);
@@ -768,6 +778,18 @@ bool Object::SameValueZero(Object* other) {
       for (int i = 0; i < 4; i++) {
         float x = a->get_lane(i);
         float y = b->get_lane(i);
+        // Implements the ES6 SameValueZero operation for floating point types.
+        // http://www.ecma-international.org/ecma-262/6.0/#sec-samevaluezero
+        if (x != y && !(std::isnan(x) && std::isnan(y))) return false;
+        // SameValueZero doesn't distinguish between 0 and -0.
+      }
+      return true;
+    } else if (IsFloat64x2() && other->IsFloat64x2()) {
+      Float64x2* a = Float64x2::cast(this);
+      Float64x2* b = Float64x2::cast(other);
+      for (int i = 0; i < 2; i++) {
+        double x = a->get_lane(i);
+        double y = b->get_lane(i);
         // Implements the ES6 SameValueZero operation for floating point types.
         // http://www.ecma-international.org/ecma-262/6.0/#sec-samevaluezero
         if (x != y && !(std::isnan(x) && std::isnan(y))) return false;

--- a/src/objects.h
+++ b/src/objects.h
@@ -891,7 +891,9 @@ template <class C> inline bool Is(Object* obj);
   V(MutableHeapNumber)             \
   V(Simd128Value)                  \
   V(Float32x4)                     \
+  V(Float64x2)                     \
   V(Int32x4)                       \
+  V(Bool64x2)                      \
   V(Bool32x4)                      \
   V(Int16x8)                       \
   V(Bool16x8)                      \
@@ -1618,7 +1620,9 @@ class Simd128Value : public HeapObject {
 // V has parameters (TYPE, Type, type, lane count, lane type)
 #define SIMD128_TYPES(V)                       \
   V(FLOAT32X4, Float32x4, float32x4, 4, float) \
+  V(FLOAT64x2, Float64x2, float64x2, 2, double)\
   V(INT32X4, Int32x4, int32x4, 4, int32_t)     \
+  V(BOOL64x2, Bool64x2, bool64x2, 2, bool)     \
   V(BOOL32X4, Bool32x4, bool32x4, 4, bool)     \
   V(INT16X8, Int16x8, int16x8, 8, int16_t)     \
   V(BOOL16X8, Bool16x8, bool16x8, 8, bool)     \

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -600,6 +600,187 @@ bool ParserTraits::ShortcutNumericLiteralBinaryExpression(
 }
 
 
+bool ParserTraits::BuildSIMD128LoadStoreExpression(
+    Expression** expression, ZoneList<Expression*>* arguments, int pos,
+    AstNodeFactory* factory) {
+  Property* prop = (*expression)->AsProperty();
+  Expression* tarray_op_literal = NULL;
+
+  if (prop) {
+    Property* simd_type_prop = prop->obj()->AsProperty();
+    if (simd_type_prop) {
+      VariableProxy* simd_var = simd_type_prop->obj()->AsVariableProxy();
+      if (simd_var && simd_var->raw_name() &&
+          simd_var->raw_name()->IsOneByteEqualTo("SIMD")) {
+        Literal* type_literal =  simd_type_prop->key()->AsLiteral();
+        if (type_literal && type_literal->raw_value() &&
+            type_literal->raw_value()->AsString()) {
+          const AstRawString* type_literal_raw_string =
+              type_literal->raw_value()->AsString();
+          if (type_literal_raw_string->IsOneByteEqualTo("Float32x4")) {
+            Literal* op_literal = prop->key()->AsLiteral();
+            if (op_literal && op_literal->raw_value() &&
+                op_literal->raw_value()->AsString()) {
+              const AstRawString* op_raw_string =
+                  op_literal->raw_value()->AsString();
+              AstValueFactory* ast_factory = parser_->ast_value_factory();
+              if (op_raw_string->IsOneByteEqualTo("load")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_getFloat32x4XYZW");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("loadX")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_getFloat32x4X");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("loadXY")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_getFloat32x4XY");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("loadXYZ")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_getFloat32x4XYZ");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("store")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_setFloat32x4XYZW");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("storeX")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_setFloat32x4X");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("storeXY")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_setFloat32x4XY");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("storeXYZ")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_setFloat32x4XYZ");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              }
+            }
+          } else if (type_literal_raw_string->IsOneByteEqualTo("Int32x4")) {
+            Literal* op_literal = prop->key()->AsLiteral();
+            if (op_literal && op_literal->raw_value() &&
+                op_literal->raw_value()->AsString()) {
+              const AstRawString* op_raw_string =
+                  op_literal->raw_value()->AsString();
+              AstValueFactory* ast_factory = parser_->ast_value_factory();
+              if (op_raw_string->IsOneByteEqualTo("load")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_getInt32x4XYZW");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("loadX")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_getInt32x4X");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("loadXY")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_getInt32x4XY");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("loadXYZ")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_getInt32x4XYZ");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("store")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_setInt32x4XYZW");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("storeX")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_setInt32x4X");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("storeXY")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_setInt32x4XY");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("storeXYZ")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_setInt32x4XYZ");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              }
+            }
+          } else if (type_literal_raw_string->IsOneByteEqualTo("Float64x2")) {
+            Literal* op_literal = prop->key()->AsLiteral();
+            if (op_literal && op_literal->raw_value() &&
+                op_literal->raw_value()->AsString()) {
+              const AstRawString* op_raw_string =
+                  op_literal->raw_value()->AsString();
+              AstValueFactory* ast_factory = parser_->ast_value_factory();
+              if (op_raw_string->IsOneByteEqualTo("load")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_getFloat64x2XY");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("loadX")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_getFloat64x2X");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("store")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_setFloat64x2XY");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              } else if (op_raw_string->IsOneByteEqualTo("storeX")) {
+                const AstRawString* op_str =
+                    ast_factory->GetOneByteString("_setFloat64x2X");
+                tarray_op_literal =
+                    factory->NewStringLiteral(op_str, RelocInfo::kNoPosition);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (tarray_op_literal) {
+    if (arguments && arguments->length() == 2) {
+      Expression* tarray = arguments->at(0);
+      Expression* index = arguments->at(1);
+      Expression* tarray_op =
+          factory->NewProperty(tarray, tarray_op_literal, pos);
+      Zone* zone = parser_->zone();
+      ZoneList<Expression*>* tarray_op_args =
+          new (zone) ZoneList<Expression*>(1, zone);
+      tarray_op_args->Add(index, zone);
+      *expression = factory->NewCall(tarray_op, tarray_op_args, pos);
+      return true;
+    } else if (arguments && arguments->length() == 3) {
+      Expression* tarray = arguments->at(0);
+      Expression* index = arguments->at(1);
+      Expression* value = arguments->at(2);
+      Expression* tarray_op =
+          factory->NewProperty(tarray, tarray_op_literal, pos);
+      Zone* zone = parser_->zone();
+      ZoneList<Expression*>* tarray_op_args =
+          new (zone) ZoneList<Expression*>(1, zone);
+      tarray_op_args->Add(index, zone);
+      tarray_op_args->Add(value, zone);
+      *expression = factory->NewCall(tarray_op, tarray_op_args, pos);
+      return true;
+    }
+  }
+  return false;
+}
+
+
 Expression* ParserTraits::BuildUnaryExpression(Expression* expression,
                                                Token::Value op, int pos,
                                                AstNodeFactory* factory) {

--- a/src/parser.h
+++ b/src/parser.h
@@ -665,6 +665,14 @@ class ParserTraits {
                                               Token::Value op, int pos,
                                               AstNodeFactory* factory);
 
+  // If we find a SIMD load or store call with array types
+  // and offset as arguments, we will return an expression
+  // calling array types load or store with offset as argument.
+  // Otherwise, returns NULL.
+  bool BuildSIMD128LoadStoreExpression(
+      Expression** expression, ZoneList<Expression*>* arguments, int pos,
+      AstNodeFactory* factory);
+
   // Rewrites the following types of unary expressions:
   // not <literal> -> true / false
   // + <numeric literal> -> <numeric literal>

--- a/src/preparser.h
+++ b/src/preparser.h
@@ -1465,6 +1465,14 @@ class PreParserTraits {
     return false;
   }
 
+  bool BuildSIMD128LoadStoreExpression(
+      PreParserExpression* expression,
+      PreParserExpressionList arguments,
+      int pos,
+      PreParserFactory* factory) {
+    return false;
+  }
+
   PreParserExpression BuildUnaryExpression(PreParserExpression expression,
                                            Token::Value op, int pos,
                                            PreParserFactory* factory) {
@@ -3206,6 +3214,10 @@ ParserBase<Traits>::ParseLeftHandSideExpression(
         Scanner::Location spread_pos;
         typename Traits::Type::ExpressionList args =
             ParseArguments(&spread_pos, classifier, CHECK_OK);
+
+        if (this->BuildSIMD128LoadStoreExpression(
+            &result, args, pos, factory()))
+          break;
 
         // Keep track of eval() calls since they disable all local variable
         // optimizations.

--- a/src/runtime/runtime-array.cc
+++ b/src/runtime/runtime-array.cc
@@ -958,7 +958,7 @@ RUNTIME_FUNCTION(Runtime_EstimateNumberOfElements) {
         ++holes;
       }
     }
-    int estimate = static_cast<int>((kNumberOfHoleCheckSamples - holes) /
+    int estimate = static_cast<int>((kNumberOfHoleCheckSamples - holes)/
                                     kNumberOfHoleCheckSamples * length);
     return Smi::FromInt(estimate);
   }

--- a/src/runtime/runtime-simd.cc
+++ b/src/runtime/runtime-simd.cc
@@ -32,6 +32,12 @@ float ConvertNumber<float>(double number) {
 
 
 template <>
+double ConvertNumber<double>(double number) {
+  return number;
+}
+
+
+template <>
 int32_t ConvertNumber<int32_t>(double number) {
   return DoubleToInt32(number);
 }
@@ -160,6 +166,8 @@ RUNTIME_FUNCTION(Runtime_SimdSameValue) {
     if (a->map() == b->map()) {
       if (a->IsFloat32x4()) {
         result = Float32x4::cast(*a)->SameValue(Float32x4::cast(b));
+      } else if (a->IsFloat64x2()) {
+        result = Float64x2::cast(*a)->SameValue(Float64x2::cast(b));
       } else {
         result = a->BitwiseEquals(b);
       }
@@ -180,6 +188,8 @@ RUNTIME_FUNCTION(Runtime_SimdSameValueZero) {
     if (a->map() == b->map()) {
       if (a->IsFloat32x4()) {
         result = Float32x4::cast(*a)->SameValueZero(Float32x4::cast(b));
+      } else if (a->IsFloat64x2()) {
+        result = Float64x2::cast(*a)->SameValueZero(Float64x2::cast(b));
       } else {
         result = a->BitwiseEquals(b);
       }
@@ -242,7 +252,9 @@ RUNTIME_FUNCTION(Runtime_SimdSameValueZero) {
 
 #define SIMD_ALL_TYPES(FUNCTION)                            \
   FUNCTION(Float32x4, float, 4, NewNumber, GET_NUMERIC_ARG) \
+  FUNCTION(Float64x2, double, 2, NewNumber, GET_NUMERIC_ARG) \
   FUNCTION(Int32x4, int32_t, 4, NewNumber, GET_NUMERIC_ARG) \
+  FUNCTION(Bool64x2, bool, 2, ToBoolean, GET_BOOLEAN_ARG)   \
   FUNCTION(Bool32x4, bool, 4, ToBoolean, GET_BOOLEAN_ARG)   \
   FUNCTION(Int16x8, int16_t, 8, NewNumber, GET_NUMERIC_ARG) \
   FUNCTION(Bool16x8, bool, 8, ToBoolean, GET_BOOLEAN_ARG)   \
@@ -386,13 +398,19 @@ SIMD_ALL_TYPES(SIMD_SHUFFLE_FUNCTION)
     return *result;                                                 \
   }
 
-SIMD_ABS_FUNCTION(Float32x4, float, 4)
-SIMD_SQRT_FUNCTION(Float32x4, float, 4)
-SIMD_RECIP_APPROX_FUNCTION(Float32x4, float, 4)
-SIMD_RECIP_SQRT_APPROX_FUNCTION(Float32x4, float, 4)
-SIMD_DIV_FUNCTION(Float32x4, float, 4)
-SIMD_MINNUM_FUNCTION(Float32x4, float, 4)
-SIMD_MAXNUM_FUNCTION(Float32x4, float, 4)
+#define SIMD_FLOAT_TYPES(FUNCTION)                 \
+FUNCTION(Float32x4, float, 4)                      \
+FUNCTION(Float64x2, double, 2)
+
+SIMD_FLOAT_TYPES(SIMD_ABS_FUNCTION)
+SIMD_FLOAT_TYPES(SIMD_SQRT_FUNCTION)
+SIMD_FLOAT_TYPES(SIMD_RECIP_APPROX_FUNCTION)
+SIMD_FLOAT_TYPES(SIMD_RECIP_SQRT_APPROX_FUNCTION)
+SIMD_FLOAT_TYPES(SIMD_DIV_FUNCTION)
+SIMD_FLOAT_TYPES(SIMD_MINNUM_FUNCTION)
+SIMD_FLOAT_TYPES(SIMD_MAXNUM_FUNCTION)
+
+#undef SIMD_FLOAT_TYPES
 
 //-------------------------------------------------------------------
 
@@ -470,6 +488,7 @@ SIMD_INT_TYPES(SIMD_ASR_FUNCTION)
 // Bool-only functions.
 
 #define SIMD_BOOL_TYPES(FUNCTION) \
+  FUNCTION(Bool64x2, 2)           \
   FUNCTION(Bool32x4, 4)           \
   FUNCTION(Bool16x8, 8)           \
   FUNCTION(Bool8x16, 16)
@@ -539,6 +558,7 @@ SIMD_SMALL_INT_TYPES(SIMD_SUB_SATURATE_FUNCTION)
 
 #define SIMD_NUMERIC_TYPES(FUNCTION) \
   FUNCTION(Float32x4, float, 4)      \
+  FUNCTION(Float64x2, double, 2)      \
   FUNCTION(Int32x4, int32_t, 4)      \
   FUNCTION(Int16x8, int16_t, 8)      \
   FUNCTION(Int8x16, int8_t, 16)
@@ -601,12 +621,14 @@ SIMD_NUMERIC_TYPES(SIMD_MAX_FUNCTION)
 
 #define SIMD_RELATIONAL_TYPES(FUNCTION) \
   FUNCTION(Float32x4, Bool32x4, 4)      \
+  FUNCTION(Float64x2, Bool64x2, 2)      \
   FUNCTION(Int32x4, Bool32x4, 4)        \
   FUNCTION(Int16x8, Bool16x8, 8)        \
   FUNCTION(Int8x16, Bool8x16, 16)
 
 #define SIMD_EQUALITY_TYPES(FUNCTION) \
   SIMD_RELATIONAL_TYPES(FUNCTION)     \
+  FUNCTION(Bool64x2, Bool64x2, 2)     \
   FUNCTION(Bool32x4, Bool32x4, 4)     \
   FUNCTION(Bool16x8, Bool16x8, 8)     \
   FUNCTION(Bool8x16, Bool8x16, 16)
@@ -669,6 +691,7 @@ SIMD_RELATIONAL_TYPES(SIMD_GREATER_THAN_OR_EQUAL_FUNCTION)
   FUNCTION(Int32x4, int32_t, 4, _INT) \
   FUNCTION(Int16x8, int16_t, 8, _INT) \
   FUNCTION(Int8x16, int8_t, 16, _INT) \
+  FUNCTION(Bool64x2, bool, 2, _BOOL)  \
   FUNCTION(Bool32x4, bool, 4, _BOOL)  \
   FUNCTION(Bool16x8, bool, 8, _BOOL)  \
   FUNCTION(Bool8x16, bool, 16, _BOOL)
@@ -720,6 +743,7 @@ SIMD_LOGICAL_TYPES(SIMD_NOT_FUNCTION)
 
 #define SIMD_SELECT_TYPES(FUNCTION)       \
   FUNCTION(Float32x4, float, Bool32x4, 4) \
+  FUNCTION(Float64x2, double, Bool64x2, 2)\
   FUNCTION(Int32x4, int32_t, Bool32x4, 4) \
   FUNCTION(Int16x8, int16_t, Bool16x8, 8) \
   FUNCTION(Int8x16, int8_t, Bool8x16, 16)
@@ -748,7 +772,9 @@ SIMD_SELECT_TYPES(SIMD_SELECT_FUNCTION)
 
 #define SIMD_FROM_TYPES(FUNCTION)                 \
   FUNCTION(Float32x4, float, 4, Int32x4, int32_t) \
-  FUNCTION(Int32x4, int32_t, 4, Float32x4, float)
+  FUNCTION(Int32x4, int32_t, 4, Float32x4, float) \
+  FUNCTION(Float64x2, double, 2, Int32x4, int32_t)\
+  FUNCTION(Float64x2, double, 2, Float32x4, float)
 
 #define SIMD_FROM_FUNCTION(type, lane_type, lane_count, from_type, from_ctype) \
   RUNTIME_FUNCTION(Runtime_##type##From##from_type) {                          \
@@ -772,6 +798,8 @@ SIMD_FROM_TYPES(SIMD_FROM_FUNCTION)
   FUNCTION(Float32x4, float, 4, Int32x4)   \
   FUNCTION(Float32x4, float, 4, Int16x8)   \
   FUNCTION(Float32x4, float, 4, Int8x16)   \
+  FUNCTION(Float64x2, double, 2, Int32x4)  \
+  FUNCTION(Float64x2, double, 2, Float32x4)\
   FUNCTION(Int32x4, int32_t, 4, Float32x4) \
   FUNCTION(Int32x4, int32_t, 4, Int16x8)   \
   FUNCTION(Int32x4, int32_t, 4, Int8x16)   \
@@ -817,5 +845,142 @@ RUNTIME_FUNCTION(Runtime_Int8x16UnsignedExtractLane) {
   CONVERT_SIMD_LANE_ARG_CHECKED(lane, 1, 16);
   return *isolate->factory()->NewNumber(bit_cast<uint8_t>(a->get_lane(lane)));
 }
+
+
+template <int n>
+inline void CopyBytes(uint8_t* target, uint8_t* source) {
+  for (int i = 0; i < n; i++) {
+    *(target++) = *(source++);
+  }
+}
+
+
+template<typename T, int Bytes>
+inline static bool SimdTypeLoadValue(
+    Isolate* isolate,
+    Handle<JSArrayBuffer> buffer,
+    Handle<Object> byte_offset_obj,
+    T* result) {
+  size_t byte_offset = 0;
+  if (!TryNumberToSize(isolate, *byte_offset_obj, &byte_offset)) {
+    return false;
+  }
+
+  size_t buffer_byte_length =
+      NumberToSize(isolate, buffer->byte_length());
+  if (byte_offset + Bytes > buffer_byte_length)  {  // overflow
+    return false;
+  }
+
+  union Value {
+    T data;
+    uint8_t bytes[sizeof(T)];
+  };
+
+  Value value;
+  memset(value.bytes, 0, sizeof(T));
+  uint8_t* source =
+      static_cast<uint8_t*>(buffer->backing_store()) + byte_offset;
+  DCHECK(Bytes <= sizeof(T));
+  CopyBytes<Bytes>(value.bytes, source);
+  *result = value.data;
+  return true;
+}
+
+
+template<typename T, int Bytes>
+static bool SimdTypeStoreValue(
+    Isolate* isolate,
+    Handle<JSArrayBuffer> buffer,
+    Handle<Object> byte_offset_obj,
+    T data) {
+  size_t byte_offset = 0;
+  if (!TryNumberToSize(isolate, *byte_offset_obj, &byte_offset)) {
+    return false;
+  }
+
+  size_t buffer_byte_length =
+      NumberToSize(isolate, buffer->byte_length());
+  if (byte_offset + Bytes > buffer_byte_length)  {  // overflow
+    return false;
+  }
+
+  union Value {
+    T data;
+    uint8_t bytes[sizeof(T)];
+  };
+
+  Value value;
+  value.data = data;
+
+  uint8_t* target =
+      static_cast<uint8_t*>(buffer->backing_store()) + byte_offset;
+  DCHECK(Bytes <= sizeof(T));
+  CopyBytes<Bytes>(target, value.bytes);
+  return true;
+}
+
+
+#define SIMD128_LOAD_RUNTIME_FUNCTION(Type, ValueType, Lanes, Bytes)   \
+RUNTIME_FUNCTION(Runtime_##Type##Load##Lanes) {                        \
+  HandleScope scope(isolate);                                          \
+  DCHECK(args.length() == 2);                                          \
+  CONVERT_ARG_HANDLE_CHECKED(JSArrayBuffer, buffer, 0);                \
+  CONVERT_NUMBER_ARG_HANDLE_CHECKED(offset, 1);                        \
+  ValueType result;                                                    \
+  if (SimdTypeLoadValue<ValueType, Bytes>(                             \
+          isolate, buffer, offset, &result)) {                         \
+    return *isolate->factory()->New##Type(result.storage);             \
+  } else {                                                             \
+    THROW_NEW_ERROR_RETURN_FAILURE(                                    \
+        isolate, NewRangeError(MessageTemplate::kInvalidOffset));      \
+  }                                                                    \
+}
+
+
+SIMD128_LOAD_RUNTIME_FUNCTION(Float32x4, float32x4_value_t, XYZW, 16)
+SIMD128_LOAD_RUNTIME_FUNCTION(Float32x4, float32x4_value_t, XYZ, 12)
+SIMD128_LOAD_RUNTIME_FUNCTION(Float32x4, float32x4_value_t, XY, 8)
+SIMD128_LOAD_RUNTIME_FUNCTION(Float32x4, float32x4_value_t, X, 4)
+SIMD128_LOAD_RUNTIME_FUNCTION(Float64x2, float64x2_value_t, XY, 16)
+SIMD128_LOAD_RUNTIME_FUNCTION(Float64x2, float64x2_value_t, X, 8)
+SIMD128_LOAD_RUNTIME_FUNCTION(Int32x4, int32x4_value_t, XYZW, 16)
+SIMD128_LOAD_RUNTIME_FUNCTION(Int32x4, int32x4_value_t, XYZ, 12)
+SIMD128_LOAD_RUNTIME_FUNCTION(Int32x4, int32x4_value_t, XY, 8)
+SIMD128_LOAD_RUNTIME_FUNCTION(Int32x4, int32x4_value_t, X, 4)
+
+
+#define SIMD128_STORE_RUNTIME_FUNCTION(Type, ValueType,                   \
+    Lanes, Lanes_count, Bytes)                                            \
+RUNTIME_FUNCTION(Runtime_##Type##Store##Lanes) {                          \
+  HandleScope scope(isolate);                                             \
+  DCHECK(args.length() == 3);                                             \
+  CONVERT_ARG_HANDLE_CHECKED(JSArrayBuffer, buffer, 0);                   \
+  CONVERT_NUMBER_ARG_HANDLE_CHECKED(offset, 1);                           \
+  CONVERT_ARG_CHECKED(Type, value, 2);                                    \
+  ValueType v;                                                            \
+  for (uint32_t count = 0; count < Lanes_count; count++) {                \
+    v.storage[count] = value->get_lane(count);                            \
+  }                                                                       \
+  if (SimdTypeStoreValue<ValueType, Bytes>(isolate, buffer, offset, v)) { \
+    return isolate->heap()->undefined_value();                            \
+  } else {                                                                \
+    THROW_NEW_ERROR_RETURN_FAILURE(                                       \
+      isolate, NewRangeError(MessageTemplate::kInvalidOffset));           \
+  }                                                                       \
+}
+
+
+SIMD128_STORE_RUNTIME_FUNCTION(Float32x4, float32x4_value_t, XYZW, 4, 16)
+SIMD128_STORE_RUNTIME_FUNCTION(Float32x4, float32x4_value_t, XYZ, 3, 12)
+SIMD128_STORE_RUNTIME_FUNCTION(Float32x4, float32x4_value_t, XY, 2, 8)
+SIMD128_STORE_RUNTIME_FUNCTION(Float32x4, float32x4_value_t, X, 1, 4)
+SIMD128_STORE_RUNTIME_FUNCTION(Float64x2, float64x2_value_t, XY, 2, 16)
+SIMD128_STORE_RUNTIME_FUNCTION(Float64x2, float64x2_value_t, X, 1, 8)
+SIMD128_STORE_RUNTIME_FUNCTION(Int32x4, int32x4_value_t, XYZW, 4, 16)
+SIMD128_STORE_RUNTIME_FUNCTION(Int32x4, int32x4_value_t, XYZ, 3, 12)
+SIMD128_STORE_RUNTIME_FUNCTION(Int32x4, int32x4_value_t, XY, 2, 8)
+SIMD128_STORE_RUNTIME_FUNCTION(Int32x4, int32x4_value_t, X, 1, 4)
+
 }  // namespace internal
 }  // namespace v8

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -570,12 +570,22 @@ namespace internal {
   F(SimdSameValue, 2, 1)                       \
   F(SimdSameValueZero, 2, 1)                   \
   F(CreateFloat32x4, 4, 1)                     \
+  F(CreateFloat64x2, 2, 1)                     \
   F(CreateInt32x4, 4, 1)                       \
+  F(CreateBool64x2, 2, 1)                      \
   F(CreateBool32x4, 4, 1)                      \
   F(CreateInt16x8, 8, 1)                       \
   F(CreateBool16x8, 8, 1)                      \
   F(CreateInt8x16, 16, 1)                      \
   F(CreateBool8x16, 16, 1)                     \
+  F(Float32x4LoadX, 2, 1)                      \
+  F(Float32x4LoadXY, 2, 1)                     \
+  F(Float32x4LoadXYZ, 2, 1)                    \
+  F(Float32x4LoadXYZW, 2, 1)                   \
+  F(Float32x4StoreX, 3, 1)                     \
+  F(Float32x4StoreXY, 3, 1)                    \
+  F(Float32x4StoreXYZ, 3, 1)                   \
+  F(Float32x4StoreXYZW, 3, 1)                  \
   F(Float32x4Check, 1, 1)                      \
   F(Float32x4ExtractLane, 2, 1)                \
   F(Float32x4ReplaceLane, 3, 1)                \
@@ -605,6 +615,47 @@ namespace internal {
   F(Float32x4FromInt32x4Bits, 1, 1)            \
   F(Float32x4FromInt16x8Bits, 1, 1)            \
   F(Float32x4FromInt8x16Bits, 1, 1)            \
+  F(Float64x2LoadX, 2, 1)                      \
+  F(Float64x2LoadXY, 2, 1)                     \
+  F(Float64x2StoreX, 3, 1)                     \
+  F(Float64x2StoreXY, 3, 1)                    \
+  F(Float64x2Check, 1, 1)                      \
+  F(Float64x2ExtractLane, 2, 1)                \
+  F(Float64x2ReplaceLane, 3, 1)                \
+  F(Float64x2Abs, 1, 1)                        \
+  F(Float64x2Neg, 1, 1)                        \
+  F(Float64x2Sqrt, 1, 1)                       \
+  F(Float64x2RecipApprox, 1, 1)                \
+  F(Float64x2RecipSqrtApprox, 1, 1)            \
+  F(Float64x2Add, 2, 1)                        \
+  F(Float64x2Sub, 2, 1)                        \
+  F(Float64x2Mul, 2, 1)                        \
+  F(Float64x2Div, 2, 1)                        \
+  F(Float64x2Min, 2, 1)                        \
+  F(Float64x2Max, 2, 1)                        \
+  F(Float64x2MinNum, 2, 1)                     \
+  F(Float64x2MaxNum, 2, 1)                     \
+  F(Float64x2LessThan, 2, 1)                   \
+  F(Float64x2LessThanOrEqual, 2, 1)            \
+  F(Float64x2GreaterThan, 2, 1)                \
+  F(Float64x2GreaterThanOrEqual, 2, 1)         \
+  F(Float64x2Equal, 2, 1)                      \
+  F(Float64x2NotEqual, 2, 1)                   \
+  F(Float64x2Select, 3, 1)                     \
+  F(Float64x2Swizzle, 3, 1)                    \
+  F(Float64x2Shuffle, 4, 1)                    \
+  F(Float64x2FromInt32x4, 1, 1)                \
+  F(Float64x2FromInt32x4Bits, 1, 1)            \
+  F(Float64x2FromFloat32x4, 1, 1)              \
+  F(Float64x2FromFloat32x4Bits, 1, 1)          \
+  F(Int32x4LoadX, 2, 1)                        \
+  F(Int32x4LoadXY, 2, 1)                       \
+  F(Int32x4LoadXYZ, 2, 1)                      \
+  F(Int32x4LoadXYZW, 2, 1)                     \
+  F(Int32x4StoreX, 3, 1)                       \
+  F(Int32x4StoreXY, 3, 1)                      \
+  F(Int32x4StoreXYZ, 3, 1)                     \
+  F(Int32x4StoreXYZW, 3, 1)                    \
   F(Int32x4Check, 1, 1)                        \
   F(Int32x4ExtractLane, 2, 1)                  \
   F(Int32x4ReplaceLane, 3, 1)                  \
@@ -634,6 +685,19 @@ namespace internal {
   F(Int32x4FromFloat32x4Bits, 1, 1)            \
   F(Int32x4FromInt16x8Bits, 1, 1)              \
   F(Int32x4FromInt8x16Bits, 1, 1)              \
+  F(Bool64x2Check, 1, 1)                       \
+  F(Bool64x2ExtractLane, 2, 1)                 \
+  F(Bool64x2ReplaceLane, 3, 1)                 \
+  F(Bool64x2And, 2, 1)                         \
+  F(Bool64x2Or, 2, 1)                          \
+  F(Bool64x2Xor, 2, 1)                         \
+  F(Bool64x2Not, 1, 1)                         \
+  F(Bool64x2AnyTrue, 1, 1)                     \
+  F(Bool64x2AllTrue, 1, 1)                     \
+  F(Bool64x2Equal, 2, 1)                       \
+  F(Bool64x2NotEqual, 2, 1)                    \
+  F(Bool64x2Swizzle, 3, 1)                     \
+  F(Bool64x2Shuffle, 4, 1)                     \
   F(Bool32x4Check, 1, 1)                       \
   F(Bool32x4ExtractLane, 2, 1)                 \
   F(Bool32x4ReplaceLane, 3, 1)                 \

--- a/test/mjsunit/harmony/loadstore.js
+++ b/test/mjsunit/harmony/loadstore.js
@@ -1,0 +1,254 @@
+// Copyright 2014 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Flags: --harmony-simd --harmony-tostring  --harmony-reflect
+// Flags: --allow-natives-syntax --expose-natives-as natives --noalways-opt
+
+function testFloat32x4LoadAndStore() {
+  var f32_array = new Float32Array(12);
+  for (var i = 0; i < 12; ++i)
+    f32_array[i] = 1.0 + i;
+
+  var v1 = SIMD.Float32x4.load(f32_array, 0);
+  var v2 = SIMD.Float32x4.load(f32_array, 4);
+  var v3 = SIMD.Float32x4.load(f32_array, 8);
+
+  assertEquals(1.0, SIMD.Float32x4.extractLane(v1, 0));
+  assertEquals(2.0, SIMD.Float32x4.extractLane(v1, 1));
+  assertEquals(3.0, SIMD.Float32x4.extractLane(v1, 2));
+  assertEquals(4.0, SIMD.Float32x4.extractLane(v1, 3));
+
+  assertEquals(5.0, SIMD.Float32x4.extractLane(v2, 0));
+  assertEquals(6.0, SIMD.Float32x4.extractLane(v2, 1));
+  assertEquals(7.0, SIMD.Float32x4.extractLane(v2, 2));
+  assertEquals(8.0, SIMD.Float32x4.extractLane(v2, 3));
+
+  assertEquals(9.0, SIMD.Float32x4.extractLane(v3, 0));
+  assertEquals(10.0, SIMD.Float32x4.extractLane(v3, 1));
+  assertEquals(11.0, SIMD.Float32x4.extractLane(v3, 2));
+  assertEquals(12.0, SIMD.Float32x4.extractLane(v3, 3));
+
+  SIMD.Float32x4.store(f32_array, 0, SIMD.Float32x4(12.0, 11.0, 10.0, 9.0));
+  SIMD.Float32x4.store(f32_array, 4, SIMD.Float32x4(8.0, 7.0, 6.0, 5.0));
+  SIMD.Float32x4.store(f32_array, 8, SIMD.Float32x4(4.0, 3.0, 2.0, 1.0));
+
+  for (var i = 0; i < 12; ++i)
+    assertEquals(12.0 - i, f32_array[i]);
+}
+
+testFloat32x4LoadAndStore();
+testFloat32x4LoadAndStore();
+%OptimizeFunctionOnNextCall(testFloat32x4LoadAndStore);
+testFloat32x4LoadAndStore();
+
+function testFloat32x4LoadXAndStoreX() {
+  var f32_array = new Float32Array(12);
+  for (var i = 0; i < 12; ++i)
+    f32_array[i] = 1.0 + i;
+
+  for (var i = 0; i < 12; ++i) {
+    var v = SIMD.Float32x4.loadX(f32_array, i);
+
+    assertEquals(1.0 + i, SIMD.Float32x4.extractLane(v, 0));
+    assertEquals(0.0, SIMD.Float32x4.extractLane(v, 1));
+    assertEquals(0.0, SIMD.Float32x4.extractLane(v, 2));
+    assertEquals(0.0, SIMD.Float32x4.extractLane(v, 3));
+  }
+
+  for (var i = 0; i < 12; ++i) {
+    SIMD.Float32x4.storeX(f32_array, i, SIMD.Float32x4(12.0 - i, 0.0, 0.0, 0.0));
+  }
+
+  for (var i = 0; i < 12; ++i)
+    assertEquals(12.0 - i, f32_array[i]);
+}
+
+testFloat32x4LoadXAndStoreX();
+testFloat32x4LoadXAndStoreX();
+%OptimizeFunctionOnNextCall(testFloat32x4LoadXAndStoreX);
+testFloat32x4LoadXAndStoreX();
+
+function testFloat32x4LoadXYAndStoreXY() {
+  var f32_array = new Float32Array(12);
+  for (var i = 0; i < 12; ++i)
+    f32_array[i] = 1.0 + i;
+
+  for (var i = 0; i < 12; i += 2) {
+    var v = SIMD.Float32x4.loadXY(f32_array, i);
+
+    assertEquals(1.0 + i, SIMD.Float32x4.extractLane(v, 0));
+    assertEquals(2.0 + i, SIMD.Float32x4.extractLane(v, 1));
+    assertEquals(0.0, SIMD.Float32x4.extractLane(v, 2));
+    assertEquals(0.0, SIMD.Float32x4.extractLane(v, 3));
+  }
+
+  for (var i = 0; i < 12; i += 2) {
+    SIMD.Float32x4.storeXY(f32_array, i, SIMD.Float32x4(12.0 - i, 11.0 - i, 0.0, 0.0));
+  }
+
+  for (var i = 0; i < 12; ++i)
+    assertEquals(12.0 - i, f32_array[i]);
+}
+
+testFloat32x4LoadXYAndStoreXY();
+testFloat32x4LoadXYAndStoreXY();
+%OptimizeFunctionOnNextCall(testFloat32x4LoadXYAndStoreXY);
+testFloat32x4LoadXYAndStoreXY();
+
+function testFloat32x4LoadXYZAndStoreXYZ() {
+  var f32_array = new Float32Array(12);
+  for (var i = 0; i < 12; ++i)
+    f32_array[i] = 1.0 + i;
+
+  for (var i = 0; i < 12; i += 3) {
+    var v = SIMD.Float32x4.loadXYZ(f32_array, i);
+
+    assertEquals(1.0 + i, SIMD.Float32x4.extractLane(v, 0));
+    assertEquals(2.0 + i, SIMD.Float32x4.extractLane(v, 1));
+    assertEquals(3.0 + i, SIMD.Float32x4.extractLane(v, 2));
+    assertEquals(0.0, SIMD.Float32x4.extractLane(v, 3));
+  }
+
+  for (var i = 0; i < 12; i += 3) {
+    SIMD.Float32x4.storeXYZ(f32_array, i, SIMD.Float32x4(12.0 - i, 11.0 - i, 10.0 - i, 0.0));
+  }
+
+  for (var i = 0; i < 12; ++i)
+    assertEquals(12.0 - i, f32_array[i]);
+}
+
+testFloat32x4LoadXYZAndStoreXYZ();
+testFloat32x4LoadXYZAndStoreXYZ();
+%OptimizeFunctionOnNextCall(testFloat32x4LoadXYZAndStoreXYZ);
+testFloat32x4LoadXYZAndStoreXYZ();
+
+function testFloat32x4LoadAndStoreFromInt8Array() {
+  var f32_array = new Float32Array(12);
+  for (var i = 0; i < 12; ++i)
+    f32_array[i] = 1.0 + i;
+
+  var i8_array = new Int8Array(f32_array.buffer);
+
+  var v1 = SIMD.Float32x4.load(i8_array, 0);
+  var v2 = SIMD.Float32x4.load(i8_array, 16);
+  var v3 = SIMD.Float32x4.load(i8_array, 32);
+
+  assertEquals(1.0, SIMD.Float32x4.extractLane(v1, 0));
+  assertEquals(2.0, SIMD.Float32x4.extractLane(v1, 1));
+  assertEquals(3.0, SIMD.Float32x4.extractLane(v1, 2));
+  assertEquals(4.0, SIMD.Float32x4.extractLane(v1, 3));
+
+  assertEquals(5.0, SIMD.Float32x4.extractLane(v2, 0));
+  assertEquals(6.0, SIMD.Float32x4.extractLane(v2, 1));
+  assertEquals(7.0, SIMD.Float32x4.extractLane(v2, 2));
+  assertEquals(8.0, SIMD.Float32x4.extractLane(v2, 3));
+
+  assertEquals(9.0, SIMD.Float32x4.extractLane(v3, 0));
+  assertEquals(10.0, SIMD.Float32x4.extractLane(v3, 1));
+  assertEquals(11.0, SIMD.Float32x4.extractLane(v3, 2));
+  assertEquals(12.0, SIMD.Float32x4.extractLane(v3, 3));
+
+  SIMD.Float32x4.store(i8_array, 0, SIMD.Float32x4(12.0, 11.0, 10.0, 9.0));
+  SIMD.Float32x4.store(i8_array, 16, SIMD.Float32x4(8.0, 7.0, 6.0, 5.0));
+  SIMD.Float32x4.store(i8_array, 32, SIMD.Float32x4(4.0, 3.0, 2.0, 1.0));
+
+  for (var i = 0; i < 12; ++i)
+    assertEquals(12.0 - i, f32_array[i]);
+}
+
+testFloat32x4LoadAndStoreFromInt8Array();
+testFloat32x4LoadAndStoreFromInt8Array();
+%OptimizeFunctionOnNextCall(testFloat32x4LoadAndStoreFromInt8Array);
+testFloat32x4LoadAndStoreFromInt8Array();
+
+function testFloat64x2LoadAndStore() {
+  var f64_array = new Float64Array(6);
+  for (var i = 0; i < 6; ++i)
+    f64_array[i] = 1.0 + i;
+
+  var v1 = SIMD.Float64x2.load(f64_array, 0);
+  var v2 = SIMD.Float64x2.load(f64_array, 2);
+  var v3 = SIMD.Float64x2.load(f64_array, 4);
+
+  assertEquals(1.0, SIMD.Float64x2.extractLane(v1, 0));
+  assertEquals(2.0, SIMD.Float64x2.extractLane(v1, 1));
+
+  assertEquals(3.0, SIMD.Float64x2.extractLane(v2, 0));
+  assertEquals(4.0, SIMD.Float64x2.extractLane(v2, 1));
+
+  assertEquals(5.0, SIMD.Float64x2.extractLane(v3, 0));
+  assertEquals(6.0, SIMD.Float64x2.extractLane(v3, 1));
+
+  SIMD.Float64x2.store(f64_array, 0, SIMD.Float64x2(6.0, 5.0));
+  SIMD.Float64x2.store(f64_array, 2, SIMD.Float64x2(4.0, 3.0));
+  SIMD.Float64x2.store(f64_array, 4, SIMD.Float64x2(2.0, 1.0));
+
+  for (var i = 0; i < 6; ++i)
+    assertEquals(6.0 - i, f64_array[i]);
+}
+
+testFloat64x2LoadAndStore();
+testFloat64x2LoadAndStore();
+%OptimizeFunctionOnNextCall(testFloat64x2LoadAndStore);
+testFloat64x2LoadAndStore();
+
+function testInt32x4LoadAndStore() {
+  var i32_array = new Int32Array(12);
+    for (var i = 0; i < 12; ++i)
+    i32_array[i] = 1 + i;
+
+  var v1 = SIMD.Int32x4.load(i32_array, 0);
+  var v2 = SIMD.Int32x4.load(i32_array, 4);
+  var v3 = SIMD.Int32x4.load(i32_array, 8);
+
+  assertEquals(1, SIMD.Int32x4.extractLane(v1, 0));
+  assertEquals(2, SIMD.Int32x4.extractLane(v1, 1));
+  assertEquals(3, SIMD.Int32x4.extractLane(v1, 2));
+  assertEquals(4, SIMD.Int32x4.extractLane(v1, 3));
+
+  assertEquals(5, SIMD.Int32x4.extractLane(v2, 0));
+  assertEquals(6, SIMD.Int32x4.extractLane(v2, 1));
+  assertEquals(7, SIMD.Int32x4.extractLane(v2, 2));
+  assertEquals(8, SIMD.Int32x4.extractLane(v2, 3));
+
+  assertEquals(9, SIMD.Int32x4.extractLane(v3, 0));
+  assertEquals(10, SIMD.Int32x4.extractLane(v3, 1));
+  assertEquals(11, SIMD.Int32x4.extractLane(v3, 2));
+  assertEquals(12, SIMD.Int32x4.extractLane(v3, 3));
+
+  SIMD.Int32x4.store(i32_array, 0, SIMD.Int32x4(12, 11, 10, 9));
+  SIMD.Int32x4.store(i32_array, 4, SIMD.Int32x4(8, 7, 6, 5));
+  SIMD.Int32x4.store(i32_array, 8, SIMD.Int32x4(4, 3, 2, 1));
+
+  for (var i = 0; i < 12; ++i)
+    assertEquals(12.0 - i, i32_array[i]);
+}
+
+testInt32x4LoadAndStore();
+testInt32x4LoadAndStore();
+%OptimizeFunctionOnNextCall(testInt32x4LoadAndStore);
+testInt32x4LoadAndStore();

--- a/test/mjsunit/harmony/simd.js
+++ b/test/mjsunit/harmony/simd.js
@@ -44,8 +44,7 @@ function isValidSimdString(string, value, type, lanes) {
   return true;
 }
 
-
-var simdTypeNames = ['Float32x4', 'Int32x4', 'Bool32x4',
+var simdTypeNames = ['Float32x4', 'Float64x2', 'Int32x4', 'Bool64x2', 'Bool32x4',
                                   'Int16x8', 'Bool16x8',
                                   'Int8x16', 'Bool8x16'];
 
@@ -191,6 +190,14 @@ function TestCoercions(type, lanes) {
       test(-Number.MAX_VALUE, -Infinity);
       test(Number.MIN_VALUE, 0);
       break;
+    case 'Float64x2':
+      test(0, 0);
+      test(-0, -0);
+      test(NaN, NaN);
+      test(null, 0);
+      test(undefined, NaN);
+      test("5.25", 5.25);
+      break;
     case 'Int32x4':
       test(Infinity, 0);
       test(-Infinity, 0);
@@ -320,6 +327,7 @@ function TestEquality(type, lanes) {
 
   switch (type) {
     case 'Float32x4':
+    case 'Float64x2':
       test(1, 2.5);
       test(1, 1);
       test(0, 0);
@@ -371,6 +379,7 @@ function TestSameValue(type, lanes) {
 
   switch (type) {
     case 'Float32x4':
+    case 'Float64x2':
       test(1, 2.5);
       test(1, 1);
       test(0, 0);


### PR DESCRIPTION
Add the Float64x2, Bool64x2 data types and operations in runtime.
Add load and store operation for SIMD types in runtime.
BUG=XWALK-5108