### PR TITLE
Add 'Optimize for size, Os' compile option

### DIFF
--- a/build/toolchain.gypi
+++ b/build/toolchain.gypi
@@ -1207,14 +1207,28 @@
             ],
           }],
           ['OS=="android"', {
-            'cflags!': [
-              '-O3',
-              '-Os',
-            ],
-            'cflags': [
-              '-fdata-sections',
-              '-ffunction-sections',
-              '-O2',
+            'conditions': [
+              ['use_optimize_for_size_compile_option==1', {
+                'cflags!': [
+                  '-O3',
+                  '-O2',
+                ],
+                'cflags': [
+                  '-fdata-sections',
+                  '-ffunction-sections',
+                  '-Os',
+                ],
+              }, {
+                'cflags!': [
+                  '-O3',
+                  '-Os',
+                ],
+                'cflags': [
+                  '-fdata-sections',
+                  '-ffunction-sections',
+                  '-O2',
+                ],
+              }],
             ],
           }],
           ['OS=="mac"', {


### PR DESCRIPTION
Modules like Base,Skia,cc,V8 use "increase size for speed" to
run faster.In Lite we prefer to decrease size.

With lzma,677K binary size reduced for embeddedshell.apk
Without lzma, 820K binary size reduced.

Slight performance downgrade found,it is an acceptable balance.