### PR TITLE
Temporarily roll v8/tools/clang (24e8c1c -> c3b6048).

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -29,7 +29,7 @@ deps = {
   "v8/test/test262/data":
     Var("git_url") + "/external/github.com/tc39/test262.git" + "@" + "67ba34b03a46bac4254223ae25f42c7b959540f0",
   "v8/tools/clang":
-    Var("git_url") + "/chromium/src/tools/clang.git" + "@" + "24e8c1c92fe54ef8ed7651b5850c056983354a4a",
+    Var("git_url") + "/chromium/src/tools/clang.git" + "@" + "c3b604840a63c06fa1c0c652119860e97fd57abe",
 }
 
 deps_os = {


### PR DESCRIPTION
* c3b6048 roll clang 255169:257953
* 9083924 rewrite_to_chrome_style: Dump the list of replacements to a file.

This makes the checkout match the backport we had to add to
chromium-crosswalk for M49. We need a newer clang because the one pulled
by this version of V8 crashes when building src/deoptimizer.cc with our
SIMD.js code.