### PR TITLE
Add fake condition to deopt in opcode, move Deoptimize out to trigger

### DIFF
--- a/src/crankshaft/ia32/lithium-codegen-ia32.cc
+++ b/src/crankshaft/ia32/lithium-codegen-ia32.cc
@@ -944,6 +944,7 @@ void LCodeGen::DeoptimizeIf(Condition cc, LInstruction* instr,
   RegisterEnvironmentForDeoptimization(environment, Safepoint::kNoLazyDeopt);
   DCHECK(environment->HasBeenRegistered());
   int id = environment->deoptimization_index();
+  if (never == cc) return;
   Address entry =
       Deoptimizer::GetDeoptimizationEntry(isolate(), id, bailout_type);
   if (entry == NULL) {
@@ -6082,6 +6083,7 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
   uint8_t imm8 = 0;  // for with operation
   switch (instr->op()) {
     case kFloat32x4ExtractLane: {
+      Condition cc = never;
       DCHECK(instr->hydrogen()->left()->representation().IsFloat32x4());
       DCHECK(instr->hydrogen()->right()->representation().IsInteger32());
       if (instr->hydrogen()->right()->IsConstant() &&
@@ -6114,14 +6116,15 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
           }
           __ cvtss2sd(result, xmm_scratch);
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for extractLane");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kBool32x4ExtractLane: {
+      Condition cc = never;
       DCHECK(instr->hydrogen()->left()->representation().IsBool32x4());
       DCHECK(instr->hydrogen()->right()->representation().IsInteger32());
       if (instr->hydrogen()->right()->IsConstant() &&
@@ -6162,15 +6165,16 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
           __ LoadRoot(result, Heap::kFalseValueRootIndex);
           __ bind(&done);
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for extractLane");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
 
     case kInt32x4ExtractLane: {
+      Condition cc = never;
       DCHECK(instr->hydrogen()->left()->representation().IsInt32x4());
       DCHECK(instr->hydrogen()->right()->representation().IsInteger32());
       if (instr->hydrogen()->right()->IsConstant() &&
@@ -6207,12 +6211,12 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
             __ movd(result, xmm_scratch);
           }
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for extractLane");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kFloat32x4Add:
     case kFloat32x4Sub:
@@ -6535,6 +6539,7 @@ void LCodeGen::DoTernarySIMDOperation(LTernarySIMDOperation* instr) {
       return;
     }
     case kFloat32x4ReplaceLane: {
+      Condition cc = never;
       DCHECK(instr->first()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->first()->representation().IsFloat32x4());
       DCHECK(instr->hydrogen()->second()->representation().IsInteger32());
@@ -6569,14 +6574,15 @@ void LCodeGen::DoTernarySIMDOperation(LTernarySIMDOperation* instr) {
           __ movups(result_reg, Operand(esp, 0));
           __ add(esp, Immediate(kFloat32x4Size));
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for replaceLane.");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kInt32x4ReplaceLane: {
+      Condition cc = never;
       DCHECK(instr->first()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->first()->representation().IsInt32x4());
       DCHECK(instr->hydrogen()->second()->representation().IsInteger32());
@@ -6607,12 +6613,12 @@ void LCodeGen::DoTernarySIMDOperation(LTernarySIMDOperation* instr) {
           __ movdqu(result_reg, Operand(esp, 0));
           __ add(esp, Immediate(kInt32x4Size));
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for replaceLane.");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     default:
       UNREACHABLE();
@@ -6707,6 +6713,7 @@ static uint8_t ComputeShuffleSelect(uint32_t x, uint32_t y, uint32_t z,
 void LCodeGen::DoQuinarySIMDOperation(LQuinarySIMDOperation* instr) {
   switch (instr->op()) {
     case kFloat32x4Swizzle: {
+      Condition cc = never;
       DCHECK(instr->a0()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->a0()->representation().IsFloat32x4());
       if ((instr->hydrogen()->a1()->IsConstant() &&
@@ -6724,14 +6731,15 @@ void LCodeGen::DoQuinarySIMDOperation(LQuinarySIMDOperation* instr) {
         uint8_t select = ComputeShuffleSelect(x, y, z, w);
         XMMRegister left_reg = ToFloat32x4Register(instr->a0());
         __ shufps(left_reg, left_reg, select);
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for swizzle");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kInt32x4Swizzle: {
+      Condition cc = never;
       DCHECK(instr->a0()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->a0()->representation().IsInt32x4());
       if ((instr->hydrogen()->a1()->IsConstant() &&
@@ -6749,12 +6757,12 @@ void LCodeGen::DoQuinarySIMDOperation(LQuinarySIMDOperation* instr) {
         uint8_t select = ComputeShuffleSelect(x, y, z, w);
         XMMRegister left_reg = ToInt32x4Register(instr->a0());
         __ pshufd(left_reg, left_reg, select);
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for shuffle");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     default:
       UNREACHABLE();
@@ -6767,6 +6775,7 @@ void LCodeGen::DoSenarySIMDOperation(LSenarySIMDOperation* instr) {
   switch (instr->op()) {
     case kFloat32x4Shuffle:
     case kInt32x4Shuffle: {
+      Condition cc = never;
       DCHECK(instr->a0()->Equals(instr->result()));
       if (instr->op() == kFloat32x4Shuffle) {
         DCHECK(instr->hydrogen()->a0()->representation().IsFloat32x4());
@@ -6802,7 +6811,6 @@ void LCodeGen::DoSenarySIMDOperation(LSenarySIMDOperation* instr) {
         if (num_lanes_from_lhs == 4) {
           uint8_t select = ComputeShuffleSelect(x, y, z, w);
           __ shufps(lhs, lhs, select);
-          return;
         } else if (num_lanes_from_lhs == 0) {
           x -= 4;
           y -= 4;
@@ -6811,7 +6819,6 @@ void LCodeGen::DoSenarySIMDOperation(LSenarySIMDOperation* instr) {
           uint8_t select = ComputeShuffleSelect(x, y, z, w);
           __ movaps(lhs, rhs);
           __ shufps(lhs, lhs, select);
-          return;
         } else if (num_lanes_from_lhs == 3) {
           uint8_t first_select = 0xFF;
           uint8_t second_select = 0xFF;
@@ -6834,47 +6841,43 @@ void LCodeGen::DoSenarySIMDOperation(LSenarySIMDOperation* instr) {
             __ movaps(temp, rhs);
             __ shufps(temp, lhs, first_select);
             __ shufps(lhs, temp, second_select);
-            return;
           }
 
           DCHECK(z < 4 && w < 4);
+          if (z < 4 && w < 4) {
+            if (y >= 4) {
+              y -= 4;
+              // T = (Ry Ry Lx Lx) = shufps(firstMask, lhs, rhs)
+              first_select = ComputeShuffleSelect(y, y, x, x);
+              // (Lx Ry Lz Lw) = (Tz Tx Lz Lw) = shufps(secondMask, lhs, T)
+              second_select = ComputeShuffleSelect(2, 0, z, w);
+            } else {
+              DCHECK(x >= 4);
+              x -= 4;
+              // T = (Rx Rx Ly Ly) = shufps(firstMask, lhs, rhs)
+              first_select = ComputeShuffleSelect(x, x, y, y);
+              // (Rx Ly Lz Lw) = (Tx Tz Lz Lw) = shufps(secondMask, lhs, T)
+              second_select = ComputeShuffleSelect(0, 2, z, w);
+            }
 
-          if (y >= 4) {
-            y -= 4;
-            // T = (Ry Ry Lx Lx) = shufps(firstMask, lhs, rhs)
-            first_select = ComputeShuffleSelect(y, y, x, x);
-            // (Lx Ry Lz Lw) = (Tz Tx Lz Lw) = shufps(secondMask, lhs, T)
-            second_select = ComputeShuffleSelect(2, 0, z, w);
-          } else {
-            DCHECK(x >= 4);
-            x -= 4;
-            // T = (Rx Rx Ly Ly) = shufps(firstMask, lhs, rhs)
-            first_select = ComputeShuffleSelect(x, x, y, y);
-            // (Rx Ly Lz Lw) = (Tx Tz Lz Lw) = shufps(secondMask, lhs, T)
-            second_select = ComputeShuffleSelect(0, 2, z, w);
+            __ movaps(temp, rhs);
+            __ shufps(temp, lhs, first_select);
+            __ shufps(temp, lhs, second_select);
+            __ movaps(lhs, temp);
           }
-
-          __ movaps(temp, rhs);
-          __ shufps(temp, lhs, first_select);
-          __ shufps(temp, lhs, second_select);
-          __ movaps(lhs, temp);
-          return;
         } else if (num_lanes_from_lhs == 2) {
           if (x < 4 && y < 4) {
             uint8_t select = ComputeShuffleSelect(x, y, z % 4, w % 4);
             __ shufps(lhs, rhs, select);
-            return;
           } else if (z < 4 && w < 4) {
             uint8_t select = ComputeShuffleSelect(x % 4, y % 4, z, w);
             __ movaps(temp, rhs);
             __ shufps(temp, lhs, select);
             __ movaps(lhs, temp);
-            return;
-          }
-
-          // In two shufps, for the most generic case:
-          uint8_t first_select[4], second_select[4];
-          uint32_t i = 0, j = 2, k = 0;
+          } else {
+            // In two shufps, for the most generic case:
+            uint8_t first_select[4], second_select[4];
+            uint32_t i = 0, j = 2, k = 0;
 
 #define COMPUTE_SELECT(lane)    \
   if (lane >= 4) {              \
@@ -6885,29 +6888,30 @@ void LCodeGen::DoSenarySIMDOperation(LSenarySIMDOperation* instr) {
     second_select[k++] = i++;   \
   }
 
-          COMPUTE_SELECT(x)
-          COMPUTE_SELECT(y)
-          COMPUTE_SELECT(z)
-          COMPUTE_SELECT(w)
+            COMPUTE_SELECT(x)
+            COMPUTE_SELECT(y)
+            COMPUTE_SELECT(z)
+            COMPUTE_SELECT(w)
 #undef COMPUTE_SELECT
 
-          DCHECK(i == 2 && j == 4 && k == 4);
+            DCHECK(i == 2 && j == 4 && k == 4);
 
-          int8_t select;
-          select = ComputeShuffleSelect(first_select[0], first_select[1],
-                                        first_select[2], first_select[3]);
-          __ shufps(lhs, rhs, select);
+            int8_t select;
+            select = ComputeShuffleSelect(first_select[0], first_select[1],
+                                          first_select[2], first_select[3]);
+            __ shufps(lhs, rhs, select);
 
-          select = ComputeShuffleSelect(second_select[0], second_select[1],
-                                        second_select[2], second_select[3]);
-          __ shufps(lhs, lhs, select);
+            select = ComputeShuffleSelect(second_select[0], second_select[1],
+                                          second_select[2], second_select[3]);
+            __ shufps(lhs, lhs, select);
+          }
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for shuffle");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
 
     default:

--- a/src/crankshaft/x64/lithium-codegen-x64.cc
+++ b/src/crankshaft/x64/lithium-codegen-x64.cc
@@ -4000,13 +4000,13 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
   uint8_t imm8 = 0;  // for with operation
   switch (instr->op()) {
     case kFloat32x4ExtractLane: {
-      DCHECK_EXTRACTLANE(Float32x4)
+      DCHECK_EXTRACTLANE(Float32x4);
+      Condition cc = never;
       if (instr->hydrogen()->right()->IsConstant() &&
           HConstant::cast(instr->hydrogen()->right())->HasInteger32Value()) {
         uint32_t right = ToInteger32(LConstantOperand::cast(instr->right()));
         DCHECK((right >= 0) && (right <= 3));
         XMMRegister left_reg = ToFloat32x4Register(instr->left());
-        ;
         XMMRegister result = ToDoubleRegister(instr->result());
         XMMRegister xmm_scratch = xmm0;
         imm8 = right;
@@ -4018,15 +4018,16 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
           __ pshufd(xmm_scratch, left_reg, imm8);
           __ cvtss2sd(result, xmm_scratch);
         }
-        return;
       } else {
+        cc = no_condition;
         Comment(";;; deoptimize: non-constant selector for extractLane");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kInt32x4ExtractLane: {
       DCHECK_EXTRACTLANE(Int32x4);
+      Condition cc = never;
       if (instr->hydrogen()->right()->IsConstant() &&
           HConstant::cast(instr->hydrogen()->right())->HasInteger32Value()) {
         uint32_t right = ToInteger32(LConstantOperand::cast(instr->right()));
@@ -4046,15 +4047,16 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
             __ movd(result, xmm_scratch);
           }
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for extractLane");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kBool32x4ExtractLane: {
       DCHECK_EXTRACTLANE(Bool32x4);
+      Condition cc = never;
       if (instr->hydrogen()->right()->IsConstant() &&
           HConstant::cast(instr->hydrogen()->right())->HasInteger32Value()) {
         uint32_t right = ToInteger32(LConstantOperand::cast(instr->right()));
@@ -4074,12 +4076,12 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
             __ movd(result, xmm_scratch);
           }
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for extractLane");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kFloat32x4Add:
     case kFloat32x4Sub:
@@ -4120,34 +4122,36 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
     case kFloat32x4Shuffle: {
       DCHECK(instr->left()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->left()->representation().IsFloat32x4());
+      Condition cc = never;
       if (instr->hydrogen()->right()->IsConstant() &&
           HConstant::cast(instr->hydrogen()->right())->HasInteger32Value()) {
         int32_t value = ToInteger32(LConstantOperand::cast(instr->right()));
         uint8_t select = static_cast<uint8_t>(value & 0xFF);
         XMMRegister left_reg = ToFloat32x4Register(instr->left());
         __ shufps(left_reg, left_reg, select);
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for shuffle");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kInt32x4Shuffle: {
       DCHECK(instr->left()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->left()->representation().IsInt32x4());
+      Condition cc = never;
       if (instr->hydrogen()->right()->IsConstant() &&
           HConstant::cast(instr->hydrogen()->right())->HasInteger32Value()) {
         int32_t value = ToInteger32(LConstantOperand::cast(instr->right()));
         uint8_t select = static_cast<uint8_t>(value & 0xFF);
         XMMRegister left_reg = ToInt32x4Register(instr->left());
         __ pshufd(left_reg, left_reg, select);
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for shuffle");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kInt32x4ShiftLeft:
     case kInt32x4ShiftRightArithmetic: {
@@ -4425,6 +4429,7 @@ void LCodeGen::DoTernarySIMDOperation(LTernarySIMDOperation* instr) {
       DCHECK(instr->hydrogen()->first()->representation().IsFloat32x4());
       DCHECK(instr->hydrogen()->second()->representation().IsInteger32());
       DCHECK(instr->hydrogen()->third()->representation().IsDouble());
+      Condition cc = never;
       if (instr->hydrogen()->second()->IsConstant() &&
           HConstant::cast(instr->hydrogen()->second())->HasInteger32Value()) {
         int32_t x = ToInteger32(LConstantOperand::cast(instr->second()));
@@ -4455,18 +4460,19 @@ void LCodeGen::DoTernarySIMDOperation(LTernarySIMDOperation* instr) {
           __ movups(result_reg, Operand(rsp, 0));
           __ addq(rsp, Immediate(kFloat32x4Size));
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for replacetLane");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kInt32x4ReplaceLane: {
       DCHECK(instr->first()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->first()->representation().IsInt32x4());
       DCHECK(instr->hydrogen()->second()->representation().IsInteger32());
       DCHECK(instr->hydrogen()->third()->representation().IsInteger32());
+      Condition cc = never;
       if (instr->hydrogen()->second()->IsConstant() &&
           HConstant::cast(instr->hydrogen()->second())->HasInteger32Value()) {
         int32_t x = ToInteger32(LConstantOperand::cast(instr->second()));
@@ -4493,12 +4499,12 @@ void LCodeGen::DoTernarySIMDOperation(LTernarySIMDOperation* instr) {
           __ movdqu(result_reg, Operand(rsp, 0));
           __ addq(rsp, Immediate(kInt32x4Size));
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for replacetLane");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     default:
       UNREACHABLE();
@@ -4595,6 +4601,7 @@ void LCodeGen::DoQuinarySIMDOperation(LQuinarySIMDOperation* instr) {
     case kFloat32x4Swizzle: {
       DCHECK(instr->a0()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->a0()->representation().IsFloat32x4());
+      Condition cc = never;
       if ((instr->hydrogen()->a1()->IsConstant() &&
            HConstant::cast(instr->hydrogen()->a1())->HasInteger32Value()) &&
           (instr->hydrogen()->a2()->IsConstant() &&
@@ -4610,16 +4617,17 @@ void LCodeGen::DoQuinarySIMDOperation(LQuinarySIMDOperation* instr) {
         uint8_t select = ComputeShuffleSelect(x, y, z, w);
         XMMRegister left_reg = ToFloat32x4Register(instr->a0());
         __ shufps(left_reg, left_reg, select);
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for swizzle");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     case kInt32x4Swizzle: {
       DCHECK(instr->a0()->Equals(instr->result()));
       DCHECK(instr->hydrogen()->a0()->representation().IsInt32x4());
+      Condition cc = never;
       if ((instr->hydrogen()->a1()->IsConstant() &&
            HConstant::cast(instr->hydrogen()->a1())->HasInteger32Value()) &&
           (instr->hydrogen()->a2()->IsConstant() &&
@@ -4635,12 +4643,12 @@ void LCodeGen::DoQuinarySIMDOperation(LQuinarySIMDOperation* instr) {
         uint8_t select = ComputeShuffleSelect(x, y, z, w);
         XMMRegister left_reg = ToInt32x4Register(instr->a0());
         __ pshufd(left_reg, left_reg, select);
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for shuffle");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
     default:
       UNREACHABLE();
@@ -4653,6 +4661,7 @@ void LCodeGen::DoSenarySIMDOperation(LSenarySIMDOperation* instr) {
   switch (instr->op()) {
     case kFloat32x4Shuffle:
     case kInt32x4Shuffle: {
+      Condition cc = never;
       DCHECK(instr->a0()->Equals(instr->result()));
       if (instr->op() == kFloat32x4Shuffle) {
         DCHECK(instr->hydrogen()->a0()->representation().IsFloat32x4());
@@ -4688,7 +4697,6 @@ void LCodeGen::DoSenarySIMDOperation(LSenarySIMDOperation* instr) {
         if (num_lanes_from_lhs == 4) {
           uint8_t select = ComputeShuffleSelect(x, y, z, w);
           __ shufps(lhs, lhs, select);
-          return;
         } else if (num_lanes_from_lhs == 0) {
           x -= 4;
           y -= 4;
@@ -4697,7 +4705,6 @@ void LCodeGen::DoSenarySIMDOperation(LSenarySIMDOperation* instr) {
           uint8_t select = ComputeShuffleSelect(x, y, z, w);
           __ movaps(lhs, rhs);
           __ shufps(lhs, lhs, select);
-          return;
         } else if (num_lanes_from_lhs == 3) {
           uint8_t first_select = 0xFF;
           uint8_t second_select = 0xFF;
@@ -4720,47 +4727,43 @@ void LCodeGen::DoSenarySIMDOperation(LSenarySIMDOperation* instr) {
             __ movaps(temp, rhs);
             __ shufps(temp, lhs, first_select);
             __ shufps(lhs, temp, second_select);
-            return;
           }
 
           DCHECK(z < 4 && w < 4);
+          if (z < 4 && w < 4) {
+            if (y >= 4) {
+              y -= 4;
+              // T = (Ry Ry Lx Lx) = shufps(firstMask, lhs, rhs)
+              first_select = ComputeShuffleSelect(y, y, x, x);
+              // (Lx Ry Lz Lw) = (Tz Tx Lz Lw) = shufps(secondMask, lhs, T)
+              second_select = ComputeShuffleSelect(2, 0, z, w);
+            } else {
+              DCHECK(x >= 4);
+              x -= 4;
+              // T = (Rx Rx Ly Ly) = shufps(firstMask, lhs, rhs)
+              first_select = ComputeShuffleSelect(x, x, y, y);
+              // (Rx Ly Lz Lw) = (Tx Tz Lz Lw) = shufps(secondMask, lhs, T)
+              second_select = ComputeShuffleSelect(0, 2, z, w);
+            }
 
-          if (y >= 4) {
-            y -= 4;
-            // T = (Ry Ry Lx Lx) = shufps(firstMask, lhs, rhs)
-            first_select = ComputeShuffleSelect(y, y, x, x);
-            // (Lx Ry Lz Lw) = (Tz Tx Lz Lw) = shufps(secondMask, lhs, T)
-            second_select = ComputeShuffleSelect(2, 0, z, w);
-          } else {
-            DCHECK(x >= 4);
-            x -= 4;
-            // T = (Rx Rx Ly Ly) = shufps(firstMask, lhs, rhs)
-            first_select = ComputeShuffleSelect(x, x, y, y);
-            // (Rx Ly Lz Lw) = (Tx Tz Lz Lw) = shufps(secondMask, lhs, T)
-            second_select = ComputeShuffleSelect(0, 2, z, w);
+            __ movaps(temp, rhs);
+            __ shufps(temp, lhs, first_select);
+            __ shufps(temp, lhs, second_select);
+            __ movaps(lhs, temp);
           }
-
-          __ movaps(temp, rhs);
-          __ shufps(temp, lhs, first_select);
-          __ shufps(temp, lhs, second_select);
-          __ movaps(lhs, temp);
-          return;
         } else if (num_lanes_from_lhs == 2) {
           if (x < 4 && y < 4) {
             uint8_t select = ComputeShuffleSelect(x, y, z % 4, w % 4);
             __ shufps(lhs, rhs, select);
-            return;
           } else if (z < 4 && w < 4) {
             uint8_t select = ComputeShuffleSelect(x % 4, y % 4, z, w);
             __ movaps(temp, rhs);
             __ shufps(temp, lhs, select);
             __ movaps(lhs, temp);
-            return;
-          }
-
-          // In two shufps, for the most generic case:
-          uint8_t first_select[4], second_select[4];
-          uint32_t i = 0, j = 2, k = 0;
+          } else {
+            // In two shufps, for the most generic case:
+            uint8_t first_select[4], second_select[4];
+            uint32_t i = 0, j = 2, k = 0;
 
 #define COMPUTE_SELECT(lane)    \
   if (lane >= 4) {              \
@@ -4787,13 +4790,14 @@ void LCodeGen::DoSenarySIMDOperation(LSenarySIMDOperation* instr) {
           select = ComputeShuffleSelect(second_select[0], second_select[1],
                                         second_select[2], second_select[3]);
           __ shufps(lhs, lhs, select);
+          }
         }
-        return;
       } else {
         Comment(";;; deoptimize: non-constant selector for shuffle");
-        DeoptimizeIf(no_condition, instr, Deoptimizer::kForcedDeoptToRuntime);
-        return;
+        cc = no_condition;
       }
+      DeoptimizeIf(cc, instr, Deoptimizer::kForcedDeoptToRuntime);
+      return;
     }
 
     default:

--- a/src/ia32/assembler-ia32.h
+++ b/src/ia32/assembler-ia32.h
@@ -189,32 +189,32 @@ typedef DoubleRegister SIMD128Register;
 
 enum Condition {
   // any value < 0 is considered no_condition
-  no_condition  = -1,
+  no_condition = -1,
 
-  overflow      =  0,
-  no_overflow   =  1,
-  below         =  2,
-  above_equal   =  3,
-  equal         =  4,
-  not_equal     =  5,
-  below_equal   =  6,
-  above         =  7,
-  negative      =  8,
-  positive      =  9,
-  parity_even   = 10,
-  parity_odd    = 11,
-  less          = 12,
+  overflow = 0,
+  no_overflow = 1,
+  below = 2,
+  above_equal = 3,
+  equal = 4,
+  not_equal = 5,
+  below_equal = 6,
+  above = 7,
+  negative = 8,
+  positive = 9,
+  parity_even = 10,
+  parity_odd = 11,
+  less = 12,
   greater_equal = 13,
-  less_equal    = 14,
-  greater       = 15,
-
+  less_equal = 14,
+  greater = 15,
+  never = 17,
   // aliases
-  carry         = below,
-  not_carry     = above_equal,
-  zero          = equal,
-  not_zero      = not_equal,
-  sign          = negative,
-  not_sign      = positive
+  carry = below,
+  not_carry = above_equal,
+  zero = equal,
+  not_zero = not_equal,
+  sign = negative,
+  not_sign = positive
 };
 
 


### PR DESCRIPTION
this function in any case to set the environment used to avoid check failed.
Add fake conditions refered to [Condition](https://code.google.com/p/chromium/codesearch#chromium/src/v8/src/x64/assembler-x64.h&l=253&cl=GROK&gsn=j&rcl=1459826222), move Deoptimize out to trigger this function in any case to set the environment used to avoid check failed.
It's difficult to assign environment when needed because assignation and check belong to different stages. So move deoptimizeIf out of scope to trigger this function always only if we control the condition in the deoptimization.