### PR TITLE
[Backport] Disable linter check for alpha-sorted includes.

### DIFF
--- a/tools/presubmit.py
+++ b/tools/presubmit.py
@@ -58,7 +58,6 @@ from testrunner.local import utils
 
 LINT_RULES = """
 -build/header_guard
-+build/include_alpha
 -build/include_what_you_use
 -build/namespaces
 -readability/check


### PR DESCRIPTION
This should make pull request #152 pass the presubmit checks.

From the original commit message:

> The linter (i.e. cpplint.py) no longer needs to check for alpha-sorted
> include directives because our source formatting (i.e. clang-format)
> will take care of this by now. This is the current default configuration
> of the underlying linter anyways.
>
> Note that the two tools disagree about the correct ordering about files
> containing dash characters. The ordering suggested by the formatter is
> more natural. Having the formatter trigger linter errors is not a good
> situation to be in.
>
> R=jochen@chromium.org
>
> Cr-Commit-Position: refs/heads/master@{#34985}