### PR TITLE
Fix cpplint presubmit issues.

### DIFF
--- a/src/typing-asm.cc
+++ b/src/typing-asm.cc
@@ -1493,8 +1493,6 @@ AsmTyper::VariableInfo* AsmTyper::GetVariableInfo(Variable* variable,
     if (!entry && in_function_) {
       entry =
           global_variable_type_.Lookup(variable, ComputePointerHash(variable));
-      if (entry && entry->value) {
-      }
     }
   }
   if (!entry) return NULL;

--- a/tools/presubmit.py
+++ b/tools/presubmit.py
@@ -58,7 +58,6 @@ from testrunner.local import utils
 
 LINT_RULES = """
 -build/header_guard
-+build/include_alpha
 -build/include_what_you_use
 -build/namespaces
 -readability/check


### PR DESCRIPTION
Backport an upstream commit and add a temporary one so that our
presubmit checks do not fail when cpplint is invoked:

```
src/typing-asm.cc:1496:  If statement had no body and no else clause  [whitespace/empty_if_body] [4]
src/api.cc:54:  Include "src/property.h" not in alphabetical order  [build/include_alpha] [4]
src/api.cc:57:  Include "src/runtime/runtime.h" not in alphabetical order  [build/include_alpha] [4]
```

This allows pull request #152 to pass.