### PR TITLE
Workaround to accelerate mandelbrot.

### DIFF
--- a/src/crankshaft/ia32/lithium-codegen-ia32.cc
+++ b/src/crankshaft/ia32/lithium-codegen-ia32.cc
@@ -5808,6 +5808,21 @@ void LCodeGen::DoUnarySIMDOperation(LUnarySIMDOperation* instr) {
       __ bind(&done);
       return;
     }
+    case kBool32x4AllTrue: {
+      DCHECK(instr->hydrogen()->value()->representation().IsBool32x4());
+      XMMRegister input_reg = ToBool32x4Register(instr->value());
+      Register result = ToRegister(instr->result());
+      __ movmskps(result, input_reg);
+      Label all_value, done;
+      __ xor_(result, 0xF);
+      __ j(zero, &all_value, Label::kNear);
+      __ xor_(result, result);
+      __ jmp(&done, Label::kNear);
+      __ bind(&all_value);
+      __ mov(result, 0xFF);
+      __ bind(&done);
+      return;
+    }
     case kInt32x4GetX:
     case kInt32x4GetY:
     case kInt32x4GetZ:

--- a/src/crankshaft/ia32/lithium-ia32.cc
+++ b/src/crankshaft/ia32/lithium-ia32.cc
@@ -2724,6 +2724,7 @@ LInstruction* LChunkBuilder::DoUnarySIMDOperation(HUnarySIMDOperation* instr) {
     case kInt32x4GetZ:
     case kInt32x4GetW:
     case kBool32x4AnyTrue:
+    case kBool32x4AllTrue:
     case kInt32x4GetFlagX:
     case kInt32x4GetFlagY:
     case kInt32x4GetFlagZ:

--- a/src/objects.h
+++ b/src/objects.h
@@ -6684,7 +6684,8 @@ class Script: public Struct {
   V(SIMD.Int32x4, neg, Int32x4Neg, Int32x4, Int32x4)                          \
   V(SIMD.Int32x4, not, Int32x4Not, Int32x4, Int32x4)                          \
   V(SIMD.Int32x4, splat, Int32x4Splat, Int32x4, Integer32)                    \
-  V(SIMD.Bool32x4, anyTrue, Bool32x4AnyTrue, Tagged, Bool32x4)
+  V(SIMD.Bool32x4, anyTrue, Bool32x4AnyTrue, Integer32, Bool32x4)             \
+  V(SIMD.Bool32x4, allTrue, Bool32x4AllTrue, Integer32, Bool32x4)
 
 // Do not need to install them in InstallExperimentalSIMDBuiltinFunctionIds.
 #define SIMD_UNARY_OPERATIONS_FOR_PROPERTY_ACCESS(V)                          \

--- a/src/objects.h
+++ b/src/objects.h
@@ -6745,19 +6745,19 @@ class Script: public Struct {
 #define SIMD_TERNARY_OPERATIONS(V)                                           \
   V(SIMD.Float32x4, select, Float32x4Select, Float32x4, Int32x4, Float32x4,  \
     Float32x4)                                                               \
-  V(SIMD.Int32x4, select, Int32x4Select, Int32x4, Int32x4, Int32x4, Int32x4) \
+  V(SIMD.Int32x4, select, Int32x4Select, Int32x4, Bool32x4, Int32x4, Int32x4) \
   V(SIMD.Float32x4, replaceLane, Float32x4ReplaceLane, Float32x4, Float32x4, \
     Integer32, Double)                                                       \
   V(SIMD.Int32x4, replaceLane, Int32x4ReplaceLane, Int32x4, Int32x4,         \
     Integer32, Integer32)
 
-#define SIMD_QUARTERNARY_OPERATIONS(V)                                        \
-  V(SIMD, Float32x4, Float32x4Constructor, Float32x4, Double, Double, Double, \
-    Double)                                                                   \
-  V(SIMD, Int32x4, Int32x4Constructor, Int32x4, Integer32, Integer32,         \
-    Integer32, Integer32)                                                     \
-  V(SIMD, Bool32x4, Bool32x4Constructor, Bool32x4, Integer32, Integer32,      \
-    Integer32, Integer32)
+#define SIMD_QUARTERNARY_OPERATIONS(V)                                         \
+  V(SIMD, Float32x4, Float32x4Constructor, Float32x4, Double, Double, Double,  \
+    Double)                                                                    \
+  V(SIMD, Int32x4, Int32x4Constructor, Int32x4, Integer32, Integer32,          \
+    Integer32, Integer32)                                                      \
+  V(SIMD, Bool32x4, Bool32x4Constructor, Bool32x4, Tagged, Tagged,             \
+    Tagged, Tagged)
 
 #define SIMD_QUINARY_OPERATIONS(V)                                      \
   V(SIMD.Float32x4, swizzle, Float32x4Swizzle, Float32x4, Float32x4,    \


### PR DESCRIPTION
Since mandlebrot is very critical to QA and the perfect solution needs some time, so I put a workaround to fix the performance issue first.
1.Modify parameter of SIMD.Int32x4.select in crankshaft
2.Change the method of constructor of SIMD.Bool32x4.
3. Add SIMD.Bool32x4.allTrue in crankshaft, use integer32
    instead of boolean in crankshaft for SIMD.Boole32x4.allTrue to
    accelerate mandlebrot.
4.Since it's a workaround and to be refined, so I file a ticket which is [XWALK-7064](https://crosswalk-project.org/jira/browse/XWALK-7064) to tract this issue.