### PR TITLE
Put up a workaround to accelerate mandlebrot.js on ia32 and x64

### DIFF
--- a/src/crankshaft/ia32/lithium-codegen-ia32.cc
+++ b/src/crankshaft/ia32/lithium-codegen-ia32.cc
@@ -5808,6 +5808,21 @@ void LCodeGen::DoUnarySIMDOperation(LUnarySIMDOperation* instr) {
       __ bind(&done);
       return;
     }
+    case kBool32x4AllTrue: {
+      DCHECK(instr->hydrogen()->value()->representation().IsBool32x4());
+      XMMRegister input_reg = ToBool32x4Register(instr->value());
+      Register result = ToRegister(instr->result());
+      __ movmskps(result, input_reg);
+      Label all_value, done;
+      __ xor_(result, 0xF);
+      __ j(zero, &all_value, Label::kNear);
+      __ LoadRoot(result, Heap::kFalseValueRootIndex);
+      __ jmp(&done, Label::kNear);
+      __ bind(&all_value);
+      __ LoadRoot(result, Heap::kTrueValueRootIndex);
+      __ bind(&done);
+      return;
+    }
     case kInt32x4GetX:
     case kInt32x4GetY:
     case kInt32x4GetZ:

--- a/src/crankshaft/ia32/lithium-codegen-ia32.cc
+++ b/src/crankshaft/ia32/lithium-codegen-ia32.cc
@@ -6295,11 +6295,11 @@ void LCodeGen::DoTernarySIMDOperation(LTernarySIMDOperation* instr) {
       return;
     }
     case kInt32x4Select: {
-      DCHECK(instr->hydrogen()->first()->representation().IsInt32x4());
+      DCHECK(instr->hydrogen()->first()->representation().IsBool32x4());
       DCHECK(instr->hydrogen()->second()->representation().IsInt32x4());
       DCHECK(instr->hydrogen()->third()->representation().IsInt32x4());
 
-      XMMRegister mask_reg = ToInt32x4Register(instr->first());
+      XMMRegister mask_reg = ToBool32x4Register(instr->first());
       XMMRegister left_reg = ToInt32x4Register(instr->second());
       XMMRegister right_reg = ToInt32x4Register(instr->third());
       XMMRegister result_reg = ToInt32x4Register(instr->result());
@@ -6470,20 +6470,52 @@ void LCodeGen::DoQuarternarySIMDOperation(LQuarternarySIMDOperation* instr) {
       return;
     }
     case kBool32x4Constructor: {
-      DCHECK(instr->hydrogen()->x()->representation().IsInteger32());
-      DCHECK(instr->hydrogen()->y()->representation().IsInteger32());
-      DCHECK(instr->hydrogen()->z()->representation().IsInteger32());
-      DCHECK(instr->hydrogen()->w()->representation().IsInteger32());
+      DCHECK(instr->hydrogen()->x()->representation().IsTagged());
+      DCHECK(instr->hydrogen()->y()->representation().IsTagged());
+      DCHECK(instr->hydrogen()->z()->representation().IsTagged());
+      DCHECK(instr->hydrogen()->w()->representation().IsTagged());
+      DCHECK(instr->hydrogen()->x()->type().IsBoolean());
+      DCHECK(instr->hydrogen()->y()->type().IsBoolean());
+      DCHECK(instr->hydrogen()->z()->type().IsBoolean());
+      DCHECK(instr->hydrogen()->w()->type().IsBoolean());
+
       Register x_reg = ToRegister(instr->x());
       Register y_reg = ToRegister(instr->y());
       Register z_reg = ToRegister(instr->z());
       Register w_reg = ToRegister(instr->w());
       XMMRegister result_reg = ToBool32x4Register(instr->result());
-      __ sub(esp, Immediate(kInt32x4Size));
-      __ mov(Operand(esp, 0 * kBool32Size), x_reg);
-      __ mov(Operand(esp, 1 * kBool32Size), y_reg);
-      __ mov(Operand(esp, 2 * kBool32Size), z_reg);
-      __ mov(Operand(esp, 3 * kBool32Size), w_reg);
+
+      Immediate neg(-1);
+      Label done_x, done_y, done_z, done_w;
+
+      __ xorps(result_reg, result_reg);
+      __ sub(esp, Immediate(kBool32x4Size));
+      __ movups(Operand(esp, 0 * kBool32Size), result_reg);
+
+      __ CompareRoot(x_reg, Heap::kTrueValueRootIndex);
+      __ j(not_equal, &done_x, Label::kNear);
+      __ mov(Operand(esp, 0 * kBool32Size), neg);
+      __ jmp(&done_x, Label::kNear);
+      __ bind(&done_x);
+
+      __ CompareRoot(y_reg, Heap::kTrueValueRootIndex);
+      __ j(not_equal, &done_y, Label::kNear);
+      __ mov(Operand(esp, 1 * kBool32Size), neg);
+      __ jmp(&done_y, Label::kNear);
+      __ bind(&done_y);
+
+      __ CompareRoot(z_reg, Heap::kTrueValueRootIndex);
+      __ j(not_equal, &done_z, Label::kNear);
+      __ mov(Operand(esp, 2 * kBool32Size), neg);
+      __ jmp(&done_z, Label::kNear);
+      __ bind(&done_z);
+
+      __ CompareRoot(w_reg, Heap::kTrueValueRootIndex);
+      __ j(not_equal, &done_w, Label::kNear);
+      __ mov(Operand(esp, 3 * kBool32Size), neg);
+      __ jmp(&done_w, Label::kNear);
+      __ bind(&done_w);
+
       __ movups(result_reg, Operand(esp, 0 * kInt32Size));
       __ add(esp, Immediate(kBool32x4Size));
       return;

--- a/src/crankshaft/ia32/lithium-ia32.cc
+++ b/src/crankshaft/ia32/lithium-ia32.cc
@@ -2724,6 +2724,7 @@ LInstruction* LChunkBuilder::DoUnarySIMDOperation(HUnarySIMDOperation* instr) {
     case kInt32x4GetZ:
     case kInt32x4GetW:
     case kBool32x4AnyTrue:
+    case kBool32x4AllTrue:
     case kInt32x4GetFlagX:
     case kInt32x4GetFlagY:
     case kInt32x4GetFlagZ:

--- a/src/crankshaft/x64/lithium-codegen-x64.cc
+++ b/src/crankshaft/x64/lithium-codegen-x64.cc
@@ -4322,11 +4322,11 @@ void LCodeGen::DoTernarySIMDOperation(LTernarySIMDOperation* instr) {
       return;
     }
     case kInt32x4Select: {
-      DCHECK(instr->hydrogen()->first()->representation().IsInt32x4());
+      DCHECK(instr->hydrogen()->first()->representation().IsBool32x4());
       DCHECK(instr->hydrogen()->second()->representation().IsInt32x4());
       DCHECK(instr->hydrogen()->third()->representation().IsInt32x4());
 
-      XMMRegister mask_reg = ToInt32x4Register(instr->first());
+      XMMRegister mask_reg = ToBool32x4Register(instr->first());
       XMMRegister left_reg = ToInt32x4Register(instr->second());
       XMMRegister right_reg = ToInt32x4Register(instr->third());
       XMMRegister result_reg = ToInt32x4Register(instr->result());
@@ -4497,20 +4497,52 @@ void LCodeGen::DoQuarternarySIMDOperation(LQuarternarySIMDOperation* instr) {
       return;
     }
     case kBool32x4Constructor: {
-      DCHECK(instr->hydrogen()->x()->representation().IsInteger32());
-      DCHECK(instr->hydrogen()->y()->representation().IsInteger32());
-      DCHECK(instr->hydrogen()->z()->representation().IsInteger32());
-      DCHECK(instr->hydrogen()->w()->representation().IsInteger32());
+      DCHECK(instr->hydrogen()->x()->representation().IsTagged());
+      DCHECK(instr->hydrogen()->y()->representation().IsTagged());
+      DCHECK(instr->hydrogen()->z()->representation().IsTagged());
+      DCHECK(instr->hydrogen()->w()->representation().IsTagged());
+      DCHECK(instr->hydrogen()->x()->type().IsBoolean());
+      DCHECK(instr->hydrogen()->y()->type().IsBoolean());
+      DCHECK(instr->hydrogen()->z()->type().IsBoolean());
+      DCHECK(instr->hydrogen()->w()->type().IsBoolean());
+
       Register x_reg = ToRegister(instr->x());
       Register y_reg = ToRegister(instr->y());
       Register z_reg = ToRegister(instr->z());
       Register w_reg = ToRegister(instr->w());
       XMMRegister result_reg = ToBool32x4Register(instr->result());
+
+      Immediate neg(-1);
+      Label done_x, done_y, done_z, done_w;
+
+      __ xorps(result_reg, result_reg);
       __ subq(rsp, Immediate(kBool32x4Size));
-      __ movl(Operand(rsp, 0 * kBool32Size), x_reg);
-      __ movl(Operand(rsp, 1 * kBool32Size), y_reg);
-      __ movl(Operand(rsp, 2 * kBool32Size), z_reg);
-      __ movl(Operand(rsp, 3 * kBool32Size), w_reg);
+      __ movups(Operand(rsp, 0 * kBool32Size), result_reg);
+
+      __ CompareRoot(x_reg, Heap::kTrueValueRootIndex);
+      __ j(not_equal, &done_x, Label::kNear);
+      __ movl(Operand(rsp, 0 * kBool32Size), neg);
+      __ jmp(&done_x, Label::kNear);
+      __ bind(&done_x);
+
+      __ CompareRoot(y_reg, Heap::kTrueValueRootIndex);
+      __ j(not_equal, &done_y, Label::kNear);
+      __ movl(Operand(rsp, 1 * kBool32Size), neg);
+      __ jmp(&done_y, Label::kNear);
+      __ bind(&done_y);
+
+      __ CompareRoot(z_reg, Heap::kTrueValueRootIndex);
+      __ j(not_equal, &done_z, Label::kNear);
+      __ movl(Operand(rsp, 2 * kBool32Size), neg);
+      __ jmp(&done_z, Label::kNear);
+      __ bind(&done_z);
+
+      __ CompareRoot(w_reg, Heap::kTrueValueRootIndex);
+      __ j(not_equal, &done_w, Label::kNear);
+      __ movl(Operand(rsp, 3 * kBool32Size), neg);
+      __ jmp(&done_w, Label::kNear);
+      __ bind(&done_w);
+
       __ movups(result_reg, Operand(rsp, 0 * kBool32Size));
       __ addq(rsp, Immediate(kBool32x4Size));
       return;
@@ -6115,7 +6147,7 @@ void LCodeGen::HandleTaggedToSIMD128(LTaggedToSIMD128* instr) {
 
   __ testp(input_reg, Immediate(kSmiTagMask));
   DeoptimizeIf(zero, instr, Deoptimizer::kSmi);
-  __ CmpObjectType(input_reg, I, kScratchRegister);
+  __ CmpObjectType(input_reg, SIMD128_VALUE_TYPE, kScratchRegister);
   DeoptimizeIf(not_equal, instr, Deoptimizer::kNotASIMD128);
 
   // Load value to SIMD register.

--- a/src/crankshaft/x64/lithium-codegen-x64.cc
+++ b/src/crankshaft/x64/lithium-codegen-x64.cc
@@ -3852,6 +3852,21 @@ void LCodeGen::DoUnarySIMDOperation(LUnarySIMDOperation* instr) {
       __ bind(&done);
       return;
     }
+    case kBool32x4AllTrue: {
+      DCHECK(instr->hydrogen()->value()->representation().IsBool32x4());
+      XMMRegister input_reg = ToBool32x4Register(instr->value());
+      Register result = ToRegister(instr->result());
+      __ movmskps(result, input_reg);
+      Label true_value, done;
+      __ xorl(result, Immediate(0xF));
+      __ j(zero, &true_value, Label::kNear);
+      __ LoadRoot(result, Heap::kFalseValueRootIndex);
+      __ jmp(&done, Label::kNear);
+      __ bind(&true_value);
+      __ LoadRoot(result, Heap::kTrueValueRootIndex);
+      __ bind(&done);
+      return;
+    }
     case kInt32x4GetX:
     case kInt32x4GetY:
     case kInt32x4GetZ:
@@ -4138,7 +4153,7 @@ void LCodeGen::DoBinarySIMDOperation(LBinarySIMDOperation* instr) {
       DCHECK(instr->hydrogen()->right()->representation().IsFloat32x4());
       XMMRegister left_reg = ToFloat32x4Register(instr->left());
       XMMRegister right_reg = ToFloat32x4Register(instr->right());
-      XMMRegister result_reg = ToInt32x4Register(instr->result());
+      XMMRegister result_reg = ToBool32x4Register(instr->result());
       switch (instr->op()) {
         case kFloat32x4LessThan:
           if (result_reg.is(left_reg)) {
@@ -4283,11 +4298,11 @@ void LCodeGen::DoTernarySIMDOperation(LTernarySIMDOperation* instr) {
   uint8_t imm8 = 0;
   switch (instr->op()) {
     case kFloat32x4Select: {
-      DCHECK(instr->hydrogen()->first()->representation().IsInt32x4());
+      DCHECK(instr->hydrogen()->first()->representation().IsBool32x4());
       DCHECK(instr->hydrogen()->second()->representation().IsFloat32x4());
       DCHECK(instr->hydrogen()->third()->representation().IsFloat32x4());
 
-      XMMRegister mask_reg = ToInt32x4Register(instr->first());
+      XMMRegister mask_reg = ToBool32x4Register(instr->first());
       XMMRegister left_reg = ToFloat32x4Register(instr->second());
       XMMRegister right_reg = ToFloat32x4Register(instr->third());
       XMMRegister result_reg = ToFloat32x4Register(instr->result());

--- a/src/crankshaft/x64/lithium-x64.cc
+++ b/src/crankshaft/x64/lithium-x64.cc
@@ -1306,6 +1306,7 @@ LInstruction* LChunkBuilder::DoUnarySIMDOperation(HUnarySIMDOperation* instr) {
     case kInt32x4GetZ:
     case kInt32x4GetW:
     case kBool32x4AnyTrue:
+    case kBool32x4AllTrue:
     case kInt32x4GetFlagX:
     case kInt32x4GetFlagY:
     case kInt32x4GetFlagZ:

--- a/src/objects.h
+++ b/src/objects.h
@@ -6742,13 +6742,13 @@ class Script: public Struct {
   V(SIMD.Bool32x4, extractLane, Bool32x4ExtractLane, Tagged, Bool32x4,         \
     Integer32)
 
-#define SIMD_TERNARY_OPERATIONS(V)                                           \
-  V(SIMD.Float32x4, select, Float32x4Select, Float32x4, Int32x4, Float32x4,  \
-    Float32x4)                                                               \
-  V(SIMD.Int32x4, select, Int32x4Select, Int32x4, Int32x4, Int32x4, Int32x4) \
-  V(SIMD.Float32x4, replaceLane, Float32x4ReplaceLane, Float32x4, Float32x4, \
-    Integer32, Double)                                                       \
-  V(SIMD.Int32x4, replaceLane, Int32x4ReplaceLane, Int32x4, Int32x4,         \
+#define SIMD_TERNARY_OPERATIONS(V)                                            \
+  V(SIMD.Float32x4, select, Float32x4Select, Float32x4, Int32x4, Float32x4,   \
+    Float32x4)                                                                \
+  V(SIMD.Int32x4, select, Int32x4Select, Int32x4, Bool32x4, Int32x4, Int32x4) \
+  V(SIMD.Float32x4, replaceLane, Float32x4ReplaceLane, Float32x4, Float32x4,  \
+    Integer32, Double)                                                        \
+  V(SIMD.Int32x4, replaceLane, Int32x4ReplaceLane, Int32x4, Int32x4,          \
     Integer32, Integer32)
 
 #define SIMD_QUARTERNARY_OPERATIONS(V)                                        \
@@ -6756,8 +6756,8 @@ class Script: public Struct {
     Double)                                                                   \
   V(SIMD, Int32x4, Int32x4Constructor, Int32x4, Integer32, Integer32,         \
     Integer32, Integer32)                                                     \
-  V(SIMD, Bool32x4, Bool32x4Constructor, Bool32x4, Integer32, Integer32,      \
-    Integer32, Integer32)
+  V(SIMD, Bool32x4, Bool32x4Constructor, Bool32x4, Tagged, Tagged, Tagged,    \
+    Tagged)
 
 #define SIMD_QUINARY_OPERATIONS(V)                                      \
   V(SIMD.Float32x4, swizzle, Float32x4Swizzle, Float32x4, Float32x4,    \

--- a/src/objects.h
+++ b/src/objects.h
@@ -6684,7 +6684,8 @@ class Script: public Struct {
   V(SIMD.Int32x4, neg, Int32x4Neg, Int32x4, Int32x4)                          \
   V(SIMD.Int32x4, not, Int32x4Not, Int32x4, Int32x4)                          \
   V(SIMD.Int32x4, splat, Int32x4Splat, Int32x4, Integer32)                    \
-  V(SIMD.Bool32x4, anyTrue, Bool32x4AnyTrue, Tagged, Bool32x4)
+  V(SIMD.Bool32x4, anyTrue, Bool32x4AnyTrue, Tagged, Bool32x4)                \
+  V(SIMD.Bool32x4, allTrue, Bool32x4AllTrue, Tagged, Bool32x4)
 
 // Do not need to install them in InstallExperimentalSIMDBuiltinFunctionIds.
 #define SIMD_UNARY_OPERATIONS_FOR_PROPERTY_ACCESS(V)                          \

--- a/test/mjsunit/harmony/simd/bool32x4.js
+++ b/test/mjsunit/harmony/simd/bool32x4.js
@@ -1,0 +1,55 @@
+// Copyright 2011 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Flags: --harmony-simd
+// Flags: --allow-natives-syntax --expose-natives-as natives --noalways-opt
+
+function testAnyTrue() {
+  var a = SIMD.Bool32x4.anyTrue(SIMD.Bool32x4(true, true, true, false));
+  assertEquals(true, a);
+
+  var b = SIMD.Bool32x4.anyTrue(SIMD.Bool32x4(false, false, false, false));
+  assertEquals(false, b);
+}
+
+testAnyTrue();
+testAnyTrue();
+%OptimizeFunctionOnNextCall(testAnyTrue);
+testAnyTrue();
+
+function testAllTrue() {
+  var a = SIMD.Bool32x4.allTrue(SIMD.Bool32x4(true, true, true, true));
+  assertEquals(true, a);
+
+  var b = SIMD.Bool32x4.allTrue(SIMD.Bool32x4(true, false, true, true));
+  assertEquals(false, b);
+}
+
+testAllTrue();
+testAllTrue();
+%OptimizeFunctionOnNextCall(testAllTrue);
+testAllTrue();


### PR DESCRIPTION
 Add SIMD.Bool32x4.allTrue in crankshaft, use SIMD.Int32x4 to represent result of SIMD.Float32x4.lessThanOrEqual to accelerate mandlebrot, wirte testcase for SIMID.Bool32x4.anyTrue and SIMD.Bool32x4.allTrue. It's a workaround, the acceleration is as bellow:
Mandelbrot:            Iterations(    715459), SIMD(  300ms), Non-SIMD( 1030ms), Speedup(3.433)

BUG=XWALK-6040