### PR TITLE
[Backport][gn] Turn on external_startup_data by default except on ios

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -28,7 +28,7 @@ declare_args() {
 
   # Use external files for startup data blobs:
   # the JS builtins sources and the start snapshot.
-  v8_use_external_startup_data = true
+  v8_use_external_startup_data = !is_ios
 
   # Sets -DVERIFY_HEAP.
   v8_enable_verify_heap = false


### PR DESCRIPTION
This is required for Crosswalk because we change the value of
external_startup_data on Android.

Original commit message:
> This sets the default for the feature, as chromium expects
> it: It is turned on for all platforms except ios.
>
> Chromium's build_override can be removed after this.
>
> This will also allow to override the value as a gn arg.
>
> BUG=chromium:474921,chromium:616034
> NOTRY=true
>
> Review-Url: https://codereview.chromium.org/2025803003