### PR TITLE
[Temp] Declare v8_use_external_startup_data in build_overrides/v8.gni

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -26,10 +26,6 @@ declare_args() {
   # http://v8project.blogspot.com/2015/09/custom-startup-snapshots.html
   v8_use_snapshot = true
 
-  # Use external files for startup data blobs:
-  # the JS builtins sources and the start snapshot.
-  v8_use_external_startup_data = !is_ios
-
   # Sets -DVERIFY_HEAP.
   v8_enable_verify_heap = false
 

--- a/build_overrides/v8.gni
+++ b/build_overrides/v8.gni
@@ -12,6 +12,10 @@ if (is_android) {
 declare_args() {
   # V8 generates code for this architecture.
   v8_target_arch = target_cpu
+
+  # Use external files for startup data blobs:
+  # the JS builtins sources and the start snapshot.
+  v8_use_external_startup_data = !is_ios
 }
 
 if (((v8_target_arch == "ia32" ||


### PR DESCRIPTION
`v8_use_external_startup_data` needs to be declared in
`build_overrides/v8.gni`, not `BUILD.gn`, so that the same can be done
in M52 Chromium's own `build_overrides/v8.gni`. This finally makes it
possible to change the value of this variable like we need to.

This is only needed in M52's V8, which does not have `gni/v8.gni`. A
similar change is also required in chromium-crosswalk.